### PR TITLE
Separate IStackInventory interface tests from StackInventory implementation tests

### DIFF
--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
@@ -1,8 +1,8 @@
 ﻿using TheChest.Core.Slots.Interfaces;
 
-namespace TheChest.Inventories.Tests.Containers
+namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void AddItem_EmptyInventory_AddsToFirstEmptySlot()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(100)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItems.cs
@@ -1,8 +1,8 @@
 ﻿using TheChest.Core.Slots.Interfaces;
 
-namespace TheChest.Inventories.Tests.Containers
+namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void AddItems_AddingEmptyArray_ThrowsArgumentException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(100)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItem.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void CanAddItem_NullItem_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
@@ -1,8 +1,8 @@
 ﻿using NUnit.Framework.Internal;
 
-namespace TheChest.Inventories.Tests.Containers
+namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void CanAddItemAt_NullItem_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItems.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void CanAddItems_NullItem_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void CanAddItemsAt_NullItems_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanMove.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanMove.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(100)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(100)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllFrom.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void GetAllFrom_EmptySlot_ReturnsEmptyArray()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllItems.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void GetAllItems_InvalidItem_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmount.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(0)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmountFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmountFrom.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(100)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetCount.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void GetCount_InvalidItem_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(100)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void GetItem_InvalidItem_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItems.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void GetItems_WhenAmountIsZeroOrSmaller_ThrowsArgumentOutOfRangeException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Move.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Move.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [TestCase(-1)]
         [TestCase(100)]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Replace.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void CanReplace_NullItems_ThrowsArgumentNullException()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.clear.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.clear.cs
@@ -1,6 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers
+﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
-    public partial class StackInventoryTests<T>
+    public partial class IStackInventoryTests<T>
     {
         [Test]
         public void Clear_EmptyInventory_ReturnsEmptyArray()

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.cs
@@ -1,0 +1,18 @@
+﻿using TheChest.Tests.Common;
+using TheChest.Tests.Common.DependencyInjection;
+using TheChest.Inventories.Tests.Containers.Interfaces.Factories;
+
+namespace TheChest.Inventories.Tests.Containers.Interfaces
+{
+    public partial class IStackInventoryTests<T> : BaseTest<T>
+    {
+        protected readonly IStackInventoryFactory<T> containerFactory;
+        protected readonly ISlotItemFactory<T> itemFactory;
+
+        protected IStackInventoryTests(Action<DIContainer> configure) : base(configure)
+        {
+            this.containerFactory = this.configurations.Resolve<IStackInventoryFactory<T>>();
+            this.itemFactory = this.configurations.Resolve<ISlotItemFactory<T>>();
+        }
+    }
+}

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.cs
@@ -1,20 +1,26 @@
-﻿using TheChest.Inventories.Tests.Containers.Interfaces.Factories;
+﻿using TheChest.Inventories.Containers;
+using TheChest.Inventories.Slots;
+using TheChest.Tests.Common.Items.ReferenceType;
+using TheChest.Tests.Common.Items.ValueType;
+using TheChest.Inventories.Tests.Containers.Factories;
+using TheChest.Inventories.Tests.Containers.Interfaces;
+using TheChest.Inventories.Tests.Containers.Interfaces.Factories;
+using TheChest.Inventories.Tests.Slots.Factories;
+using TheChest.Inventories.Tests.Slots.Factories.Interfaces;
 
 namespace TheChest.Inventories.Tests.Containers
 {
-    public abstract partial class StackInventoryTests<T> 
+    [TestFixture(typeof(TestItem))]
+    [TestFixture(typeof(TestStructItem))]
+    [TestFixture(typeof(TestEnumItem))]
+    public partial class StackInventoryTests<T> : IStackInventoryTests<T>
     {
-        protected readonly IStackInventoryFactory<T> containerFactory;
-        protected readonly ISlotItemFactory<T> itemFactory;
-
-        protected readonly Random random;
-
-        public StackInventoryTests(IStackInventoryFactory<T> containerFactory, ISlotItemFactory<T> itemFactory)
-        { 
-            this.containerFactory = containerFactory;
-            this.itemFactory = itemFactory;
-        
-            this.random = new Random();
-        }
+        public StackInventoryTests() : base(configure =>
+        {
+            configure
+                .Register<IInventoryStackSlotFactory<T>, InventoryStackSlotFactory<InventoryStackSlot<T>, T>>()
+                .Register<IStackInventoryFactory<T>, StackInventoryFactory<StackInventory<T>, T>>()
+                .Register<ISlotItemFactory<T>, SlotItemFactory<T>>();
+        }) { }
     }
 }


### PR DESCRIPTION
## Summary
- moved all `StackInventoryTests` interface-focused partial test files into `tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory`
- renamed the moved partial classes/files from `StackInventoryTests.*` to `IStackInventoryTests.*`
- added a new `IStackInventoryTests<T>` base partial class (DI-backed) in the new interface folder
- converted `Containers/StackInventory/StackInventoryTests.cs` into an implementation test entry class that inherits `IStackInventoryTests<T>` and wires registrations, following the `IInventoryTests`/`InventoryTests` pattern

## Notes
- test behavior was preserved; only folder/file organization and partial class ownership were changed
- no test execution was performed

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68f54412c83238eace9910adbbea6)