### PR TITLE
Refactor StackInventory tests to use DI-resolved inventoryFactory and add generic test fixtures

### DIFF
--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
@@ -8,7 +8,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_EmptyInventory_AddsToFirstEmptySlot()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             inventory.Add(item);
             
@@ -24,7 +24,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_EmptyInventory_CallsOnAddEvent()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var raised = false;
             inventory.OnAdd += (sender, args) =>
@@ -47,7 +47,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_EmptyInventory_ReturnsTrue()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var result = inventory.Add(item);
 
@@ -58,7 +58,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_InventoryWithItems_AddsToAvailableSlot()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, 10, this.itemFactory.CreateManyRandom(10));
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, 10, this.itemFactory.CreateManyRandom(10));
 
             inventory.Add(item);
             
@@ -74,7 +74,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var item = this.itemFactory.CreateDefault();
             var size = this.random.Next(2, 20);
             var stackSize = this.random.Next(2, 10);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var expectedIndex = this.random.Next(0, size);
             inventory.GetAll(expectedIndex);
 
@@ -100,7 +100,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         {
             var item = this.itemFactory.CreateDefault();
             var amount = this.random.Next(2, 10);
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, amount, item);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, amount, item);
             inventory.Get(item, amount - 1);
 
             inventory.Add(item);
@@ -119,7 +119,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var item = this.itemFactory.CreateDefault();
             var size = this.random.Next(2, 20);
             var stackSize = this.random.Next(2, 10);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var expectedIndex = this.random.Next(0, size);
             inventory.GetAll(expectedIndex);
 
@@ -140,7 +140,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var items = this.itemFactory.CreateManyRandom(19)
                 .Append(this.itemFactory.CreateDefault())
                 .ToArray();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, 10, items);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, 10, items);
             var slots = inventory.GetSlots()!;
             var slotIndex = Array.IndexOf(slots, slots.First(x => x.GetContents()?.Contains(item) ?? false));
             inventory.Get(slotIndex, 9);
@@ -159,7 +159,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_FullInventory_DoesNotAddToSlot()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(10,10, this.itemFactory.CreateRandom());
+            var inventory = this.inventoryFactory.FullContainer(10,10, this.itemFactory.CreateRandom());
 
             inventory.Add(item);
 
@@ -170,7 +170,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_FullInventory_DoesNotCallOnAddEvent()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(10, 10, this.itemFactory.CreateRandom());
+            var inventory = this.inventoryFactory.FullContainer(10, 10, this.itemFactory.CreateRandom());
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
             inventory.Add(item);
         }
@@ -179,7 +179,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_FullInventory_ReturnsFalse()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(10, 10, this.itemFactory.CreateRandom());
+            var inventory = this.inventoryFactory.FullContainer(10, 10, this.itemFactory.CreateRandom());
 
             var result = inventory.Add(item);
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
@@ -72,7 +72,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_InventoryWithItems_CallsOnAddEvent()
         {
             var item = this.itemFactory.CreateDefault();
-            var size = this.random.Next(2, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 10);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var expectedIndex = this.random.Next(0, size);
@@ -117,7 +117,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItem_InventoryWithFullSlotWithSameItem_AddsToFirstAvailableSlot()
         {
             var item = this.itemFactory.CreateDefault();
-            var size = this.random.Next(2, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 10);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var expectedIndex = this.random.Next(0, size);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
@@ -7,7 +7,7 @@
         public void AddItemAt_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             Assert.That(() => inventory.AddAt(item, index), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
@@ -15,7 +15,7 @@
         [Test]
         public void AddItemAt_InvalidItem_ThrowsArgumentException()
         {
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             Assert.That(() => inventory.AddAt(default(T)!, 0), Throws.ArgumentNullException);
         }
@@ -24,7 +24,7 @@
         public void AddItemAt_EmptySlot_AddsToStack()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var item = this.itemFactory.CreateDefault();
             inventory.AddAt(item, index);
@@ -36,7 +36,7 @@
         public void AddItemAt_EmptySlot_CallsOnAddEvent()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var item = this.itemFactory.CreateDefault();
 
@@ -62,7 +62,7 @@
         public void AddItemAt_EmptySlot_ReturnsTrue()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var item = this.itemFactory.CreateDefault();
             var result = inventory.AddAt(item, index);
@@ -76,7 +76,7 @@
         {
             var index = this.random.Next(0, 20);
             var items = this.itemFactory.CreateManyRandom(20);
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, 5, items);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, 5, items);
 
             var item = this.itemFactory.CreateDefault();
             inventory.AddAt(item, index);
@@ -88,7 +88,7 @@
         public void AddItemAt_SlotWithDifferentItem_ReturnsFalse()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.FullContainer(20, 5, this.itemFactory.CreateRandom());
+            var inventory = this.inventoryFactory.FullContainer(20, 5, this.itemFactory.CreateRandom());
 
             var item = this.itemFactory.CreateDefault();
             var result = inventory.AddAt(item, index);
@@ -100,7 +100,7 @@
         public void AddItemAt_SlotWithDifferentItem_DoesNotCallOnAddEvent()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.FullContainer(20, 5, this.itemFactory.CreateRandom());
+            var inventory = this.inventoryFactory.FullContainer(20, 5, this.itemFactory.CreateRandom());
 
             var item = this.itemFactory.CreateDefault();
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
@@ -113,7 +113,7 @@
         {
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(20, 5, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
             inventory.Get(index);
 
             var stackSize = inventory.GetSlot(index).Amount;
@@ -128,7 +128,7 @@
         {
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(20, 5, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
             inventory.Get(index);
 
             var item = this.itemFactory.CreateDefault();
@@ -157,7 +157,7 @@
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
-            var inventory = this.containerFactory.FullContainer(20, amount, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
             inventory.Get(index);
 
             var item = this.itemFactory.CreateDefault();
@@ -171,7 +171,7 @@
         {
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(20, 5, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
             var item = this.itemFactory.CreateDefault();
 
             inventory.AddAt(item, index);
@@ -185,7 +185,7 @@
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
-            var inventory = this.containerFactory.FullContainer(20, 5, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
             var item = this.itemFactory.CreateDefault();
 
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
@@ -199,7 +199,7 @@
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
-            var inventory = this.containerFactory.FullContainer(20, 5, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
 
             var item = this.itemFactory.CreateDefault();
             var result = inventory.AddAt(item, index);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
@@ -23,7 +23,7 @@
         [Test]
         public void AddItemAt_EmptySlot_AddsToStack()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var item = this.itemFactory.CreateDefault();
@@ -35,7 +35,7 @@
         [Test]
         public void AddItemAt_EmptySlot_CallsOnAddEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var item = this.itemFactory.CreateDefault();
@@ -61,7 +61,7 @@
         [Test]
         public void AddItemAt_EmptySlot_ReturnsTrue()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var item = this.itemFactory.CreateDefault();
@@ -74,7 +74,7 @@
         [Ignore("This test is not working due Inventory creation")]
         public void AddItemAt_SlotWithDifferentItem_DoNotAddItem()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var items = this.itemFactory.CreateManyRandom(20);
             var inventory = this.inventoryFactory.ShuffledItemsContainer(20, 5, items);
 
@@ -87,7 +87,7 @@
         [Test]
         public void AddItemAt_SlotWithDifferentItem_ReturnsFalse()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(20, 5, this.itemFactory.CreateRandom());
 
             var item = this.itemFactory.CreateDefault();
@@ -99,7 +99,7 @@
         [Test]
         public void AddItemAt_SlotWithDifferentItem_DoesNotCallOnAddEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(20, 5, this.itemFactory.CreateRandom());
 
             var item = this.itemFactory.CreateDefault();
@@ -111,7 +111,7 @@
         [Test]
         public void AddItemAt_SlotWithSameItem_AddsToStack()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
             inventory.Get(index);
@@ -126,7 +126,7 @@
         [Test]
         public void AddItemAt_SlotWithSameItem_CallsOnAddEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
             inventory.Get(index);
@@ -153,7 +153,7 @@
         [Test]
         public void AddItemAt_SlotWithSameItem_ReturnsTrue()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
@@ -169,7 +169,7 @@
         [Test]
         public void AddItemAt_FullSlotWithSameItem_DoesNotAddsToStack()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
             var item = this.itemFactory.CreateDefault();
@@ -182,7 +182,7 @@
         [Test]
         public void AddItemAt_FullSlotWithSameItem_DoNotCallsOnAddEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
@@ -196,7 +196,7 @@
         [Test]
         public void AddItemAt_FullSlotWithSameItem_ReturnsFalse()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItems.cs
@@ -7,7 +7,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         [Test]
         public void AddItems_AddingEmptyArray_ThrowsArgumentException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var items = Array.Empty<T>();
             var result = inventory.Add(items);
@@ -19,7 +19,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItems_EmptyInventory_ReturnsEmptyArray()
         {
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var result = inventory.Add(items);
 
@@ -30,7 +30,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItems_EmptyInventory_AddsToFirstSlot()
         {
             var items = this.itemFactory.CreateMany(10);
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             inventory.Add(items);
 
@@ -41,7 +41,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItems_EmptyInventory_CallsOnAddEvent()
         {
             var items = this.itemFactory.CreateMany(10);
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var raised = false;
             inventory.OnAdd += (sender, args) =>
@@ -65,7 +65,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         {
             var item = this.itemFactory.CreateDefault();
             var maxSize = this.random.Next(2, 10);
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, maxSize, item);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, maxSize, item);
             inventory.Get(item, maxSize - 1);
 
             var amount = maxSize;
@@ -85,7 +85,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         {
             var item = this.itemFactory.CreateDefault();
             var maxSize = this.random.Next(2, 10);
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, maxSize, item);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, maxSize, item);
             inventory.Get(item, maxSize - 1);
 
             var amount = maxSize;
@@ -117,7 +117,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         {
             var item = this.itemFactory.CreateDefault();
             var maxSize = this.random.Next(2, 10);
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, maxSize, item);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, maxSize, item);
 
             var amount = this.random.Next(1, maxSize - 1);
             var items = this.itemFactory.CreateMany(maxSize + amount);
@@ -143,7 +143,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         {
             var item = this.itemFactory.CreateDefault();
             var maxSize = this.random.Next(2, 10);
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, maxSize, item);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, maxSize, item);
             inventory.Get(item, maxSize - 1);
 
             var amount = maxSize;
@@ -162,7 +162,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItems_EmptyInventory_BiggerAmountThanSlotSize_CallsOnAddEventOnTwoSlots()
         {
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var raised = false;
             inventory.OnAdd += (sender, args) =>
@@ -194,7 +194,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         public void AddItems_EmptyInventory_BiggerAmountThanSlotSize_AddsToTwoAvailableSlots()
         {
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             inventory.Add(items);
 
@@ -211,7 +211,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var slotItem = this.itemFactory.CreateRandom();
             var items = this.itemFactory.CreateMany(20);
             var expectedItems = items.ToArray();
-            var inventory = this.containerFactory.FullContainer(20, 2, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 2, slotItem);
 
             inventory.Add(items);
 
@@ -223,7 +223,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         {
             var slotItem = this.itemFactory.CreateRandom();
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.FullContainer(20, 2, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 2, slotItem);
 
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
             
@@ -235,7 +235,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         {
             var slotItem = this.itemFactory.CreateRandom();
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.FullContainer(20, 2, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 2, slotItem);
 
             var result = inventory.Add(items);
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
@@ -15,7 +15,7 @@
         [Test]
         public void AddItemsAt_EmptySlot_AddsToStack()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var items = this.itemFactory.CreateMany(10);
@@ -27,7 +27,7 @@
         [Test]
         public void AddItemsAt_EmptySlot_CallsOnAddEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var items = this.itemFactory.CreateMany(10);
@@ -52,7 +52,7 @@
         [Test]
         public void AddItemsAt_EmptySlot_ReturnsEmpty()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var items = this.itemFactory.CreateMany(10);
@@ -64,7 +64,7 @@
         [Test]
         public void AddItemsAt_SlotWithDifferentItem_DoesNotCallOnAddEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateRandom();
             var amount = this.random.Next(1, 10);
             var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
@@ -78,7 +78,7 @@
         [Test]
         public void AddItemsAt_SlotWithDifferentItem_ReturnsItemsFromParams()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateRandom();
             var amount = this.random.Next(1, 10);
             var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
@@ -92,7 +92,7 @@
         [Test]
         public void AddItemsAt_SlotWithSameItem_AddsToStack()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(5, 10);
@@ -114,7 +114,7 @@
         [Test]
         public void AddItemsAt_FullSlotSlotWithSameItem_ReturnsNotAddedItemsFromParam()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
@@ -129,7 +129,7 @@
         [Test]
         public void AddItemsAt_FullSlotWithSameItem_DoNotAddsToStack()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
@@ -144,7 +144,7 @@
         [Test]
         public void AddItemsAt_FullSlotWithSameItem_DoesNotCallOnAddEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
@@ -159,7 +159,7 @@
         [Test]
         public void AddItemsAt_FullSlotWithSameItem_ReturnsNotAddedItems()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
 
             var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
@@ -7,7 +7,7 @@
         public void AddItemsAt_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             Assert.That(() => inventory.AddAt(items, index), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
@@ -16,7 +16,7 @@
         public void AddItemsAt_EmptySlot_AddsToStack()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var items = this.itemFactory.CreateMany(10);
             inventory.AddAt(items, index);
@@ -28,7 +28,7 @@
         public void AddItemsAt_EmptySlot_CallsOnAddEvent()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var items = this.itemFactory.CreateMany(10);
 
@@ -53,7 +53,7 @@
         public void AddItemsAt_EmptySlot_ReturnsEmpty()
         {
             var index = this.random.Next(0, 20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             var items = this.itemFactory.CreateMany(10);
             var result = inventory.AddAt(items, index);
@@ -67,7 +67,7 @@
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var amount = this.random.Next(1, 10);
-            var inventory = this.containerFactory.FullContainer(20, amount, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
 
             var items = this.itemFactory.CreateMany(amount);
             inventory.OnAdd += (sender, e) => Assert.Fail("OnAdd event should not be called when is not possible to Add.");
@@ -81,7 +81,7 @@
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var amount = this.random.Next(1, 10);
-            var inventory = this.containerFactory.FullContainer(20, amount, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
 
             var items = this.itemFactory.CreateMany(amount);
             var result = inventory.AddAt(items, index);
@@ -96,7 +96,7 @@
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(5, 10);
-            var inventory = this.containerFactory.FullContainer(20, amount, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
             inventory.Get(index, 2); 
 
             var items = this.itemFactory.CreateMany(2);
@@ -118,7 +118,7 @@
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
-            var inventory = this.containerFactory.FullContainer(20, amount, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
 
             var items = this.itemFactory.CreateMany(amount);
             var result = inventory.AddAt(items, index);
@@ -133,7 +133,7 @@
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
-            var inventory = this.containerFactory.FullContainer(20, amount, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
 
             var items = this.itemFactory.CreateMany(10);
             inventory.AddAt(items, index);
@@ -148,7 +148,7 @@
             var slotItem = this.itemFactory.CreateDefault();
 
             var amount = this.random.Next(1, 10);
-            var inventory = this.containerFactory.FullContainer(20, amount, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, amount, slotItem);
 
             inventory.OnAdd += (sender, e) => Assert.Fail("OnAdd event should not be called when is not possible to Add.");
             
@@ -162,7 +162,7 @@
             var index = this.random.Next(0, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
-            var inventory = this.containerFactory.FullContainer(20, 5, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, 5, slotItem);
 
             var items = this.itemFactory.CreateMany(10);
             var result = inventory.AddAt(items, index);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItem.cs
@@ -5,14 +5,14 @@
         [Test]
         public void CanAddItem_NullItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.CanAdd(item: default!), Throws.ArgumentNullException);
         }
 
         [Test]
         public void CanAddItem_EmptyInventory_ReturnsTrue()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var item = this.itemFactory.CreateDefault();
 
             var canAdd = inventory.CanAdd(item);
@@ -26,7 +26,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex);
@@ -41,7 +41,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex);
@@ -58,7 +58,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var canAdd = inventory.CanAdd(item);
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItem.cs
@@ -23,7 +23,7 @@
         [Test]
         public void CanAddItem_AvailableSlotOnInventory_ReturnsTrue()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -38,7 +38,7 @@
         [Test]
         public void CanAddItem_AvailableSlotWithDifferentItemOnInventory_ReturnsTrue()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -55,7 +55,7 @@
         [Test]
         public void CanAddItem_FullInventory_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
@@ -7,7 +7,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         [Test]
         public void CanAddItemAt_NullItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.CanAddAt(item: default!, 0), Throws.ArgumentNullException);
         }
 
@@ -15,7 +15,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         [TestCase(22)]
         public void CanAddItemAt_InvalidSlotIndex_ThrowsArgumentOutOfRangeException(int index)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             Assert.That(
                 () => inventory.CanAddAt(this.itemFactory.CreateDefault(), index),
@@ -26,7 +26,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         [Test]
         public void CanAddItemAt_EmptyInventory_ReturnsTrue()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var item = this.itemFactory.CreateDefault();
 
@@ -41,7 +41,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex, stackSize - 1);
 
@@ -56,7 +56,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex, stackSize - 1);
 
@@ -72,7 +72,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             inventory.AddAt(item, randomIndex);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
@@ -38,7 +38,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         [Test]
         public void CanAddItemAt_SlotWithSameItemsAndEnoughSpace_ReturnsTrue()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -53,7 +53,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         [Test]
         public void CanAddItemAt_SlotWithDifferentItemsAndEnoughSpace_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -69,7 +69,7 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         [Test]
         public void CanAddItemAt_FullInventory_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItems.cs
@@ -5,14 +5,14 @@
         [Test]
         public void CanAddItems_NullItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.CanAdd(items: default!), Throws.ArgumentNullException);
         }
 
         [Test]
         public void CanAddItems_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var items = this.itemFactory.CreateMany(5).ToList();
             items.Add(default!);
 
@@ -22,7 +22,7 @@
         [Test]
         public void CanAddItems_EmptyItemsArray_ReturnsTrue()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var items = Array.Empty<T>();
             
             var canAdd = inventory.CanAdd(items);
@@ -33,7 +33,7 @@
         [Test]
         public void CanAddItems_EmptyInventory_ReturnsTrue()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var items = this.itemFactory.CreateMany(10);
             var canAdd = inventory.CanAdd(items);
@@ -47,7 +47,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var randomAmount = this.random.Next(2, size);
             inventory.Get(item, randomAmount - 1);
 
@@ -63,7 +63,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex, stackSize - 1);
 
@@ -80,7 +80,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex, stackSize - 1);
 
@@ -96,7 +96,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             for (int i = 0; i < stackSize; i++)
             {
@@ -116,7 +116,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var items = this.itemFactory.CreateMany(size);
             var canAdd = inventory.CanAdd(items);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItems.cs
@@ -44,7 +44,7 @@
         [Test]
         public void CanAddItems_InsufficientSpace_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -60,7 +60,7 @@
         [Test]
         public void CanAddItems_SufficientSpaceWithDifferentItem_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -77,7 +77,7 @@
         [Test]
         public void CanAddItems_SufficientSpaceWithSameItem_ReturnsTrue()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -93,7 +93,7 @@
         [Test]
         public void CanAddItems_SufficientSpaceWithSameItemInMultipleSlots_ReturnsTrue()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -113,7 +113,7 @@
         [Test]
         public void CanAddItems_FullInventory_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 5);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
@@ -5,14 +5,14 @@
         [Test]
         public void CanAddItemsAt_NullItems_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.CanAddAt(items: default!, 0), Throws.ArgumentNullException);
         }
 
         [Test]
         public void CanAddItemsAt_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var items = this.itemFactory.CreateMany(5).ToList();
             items.Add(default!);
 
@@ -23,7 +23,7 @@
         [TestCase(22)]
         public void CanAddItemsAt_InvalidSlotIndex_ThrowsArgumentOutOfRangeException(int index)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             Assert.That(
                 () => inventory.CanAddAt(this.itemFactory.CreateMany(5), index),
@@ -34,7 +34,7 @@
         [Test]
         public void CanAddItemsAt_EmptyInventory_ReturnsTrue()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var items = this.itemFactory.CreateMany(5);
 
@@ -49,7 +49,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex, stackSize);
@@ -66,7 +66,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             inventory.GetAll(randomIndex);
@@ -83,7 +83,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(5, 10);
             var randomItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, randomItem);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, randomItem);
 
             var randomIndex = this.random.Next(0, size);
             inventory.Get(randomIndex, stackSize - 1);
@@ -100,7 +100,7 @@
             var size = this.random.Next(10, 20);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             inventory.AddAt(item, randomIndex);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
@@ -46,7 +46,7 @@
         [Test]
         public void CanAddItemsAt_SlotWithSameItemsAndEnoughSpace_ReturnsTrue()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -63,7 +63,7 @@
         [Test]
         public void CanAddItemsAt_ItemsAmountBiggerThanSlotSize_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
@@ -80,7 +80,7 @@
         [Test]
         public void CanAddItemsAt_SlotWithDifferentItemsAndEnoughSpace_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 10);
             var randomItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, randomItem);
@@ -97,7 +97,7 @@
         [Test]
         public void CanAddItemsAt_FullInventory_ReturnsFalse()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 10);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanMove.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanMove.cs
@@ -26,7 +26,7 @@
         [Test]
         public void CanMove_SameOriginAndTarget_ReturnsFalse()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var originIndex = this.random.Next(0, inventorySize - 1);
             var inventory = this.inventoryFactory.EmptyContainer(inventorySize, stackSize);
@@ -39,7 +39,7 @@
         [Test]
         public void CanMove_EmptyOrigin_TargetWithItems_ReturnsTrue()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
@@ -57,7 +57,7 @@
         [Test]
         public void CanMove_OriginWithItems_EmptyTarget_ReturnsTrue()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
@@ -75,7 +75,7 @@
         [Test]
         public void Move_OriginAndTargetWithSameItems_ReturnsTrue()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
@@ -93,7 +93,7 @@
         [Test]
         public void Move_OriginAndTargetWithDifferentItems_ReturnsTrue()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItems = this.itemFactory.CreateMany(inventorySize / 2);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanMove.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanMove.cs
@@ -6,7 +6,7 @@
         [TestCase(100)]
         public void CanMove_InvalidOriginIndex_ThrowsArgumentOutOfRangeException(int origin)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(
                 () => inventory.CanMove(origin, 0),
                 Throws.TypeOf<ArgumentOutOfRangeException>()
@@ -16,7 +16,7 @@
         [TestCase(100)]
         public void CanMove_InvalidTargetIndex_ThrowsArgumentOutOfRangeException(int target)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(
                 () => inventory.CanMove(0, target),
                 Throws.TypeOf<ArgumentOutOfRangeException>()
@@ -29,7 +29,7 @@
             var inventorySize = this.random.Next(10, 20);
             var stackSize = this.random.Next(1, 20);
             var originIndex = this.random.Next(0, inventorySize - 1);
-            var inventory = this.containerFactory.EmptyContainer(inventorySize, stackSize);
+            var inventory = this.inventoryFactory.EmptyContainer(inventorySize, stackSize);
 
             var canMove = inventory.CanMove(originIndex, originIndex);
 
@@ -46,7 +46,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
             inventory.GetAll(originIndex);
 
             var canMove = inventory.CanMove(originIndex, targetIndex);
@@ -64,7 +64,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
             inventory.GetAll(targetIndex);
 
             var canMove = inventory.CanMove(originIndex, targetIndex);
@@ -82,7 +82,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
             inventory.Get(originIndex, random.Next(1, stackSize - 2));
 
             var canMove = inventory.CanMove(originIndex, targetIndex);
@@ -99,7 +99,7 @@
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);
             var inventoryItems = slotItems.Concat(randomItems).ToArray();
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(inventorySize, stackSize, inventoryItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(inventorySize, stackSize, inventoryItems);
 
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
@@ -7,7 +7,7 @@
         public void Replace_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             Assert.That(() => inventory.Replace(items, index), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
@@ -18,7 +18,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             Assert.That(() => 
@@ -33,7 +33,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var randomIndex = this.random.Next(0, size);
             var items = this.itemFactory.CreateMany(stackSize + 1);
 
@@ -50,7 +50,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             Assert.That(() =>
@@ -65,7 +65,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             var newItems = this.itemFactory.CreateManyRandom(stackSize);
@@ -80,7 +80,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             var newStackSize = this.random.Next(1, stackSize - 1);
@@ -98,7 +98,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             var newItems = this.itemFactory.CreateManyRandom(stackSize);
@@ -121,7 +121,7 @@
         {
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.EmptyContainer(size, stackSize);
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);
             var newItems = this.itemFactory.CreateManyRandom(stackSize);
@@ -135,7 +135,7 @@
         {
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.EmptyContainer(size, stackSize);
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);
             var newItems = this.itemFactory.CreateManyRandom(this.random.Next(1, stackSize));
@@ -149,7 +149,7 @@
         {
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);
             var newItems = this.itemFactory.CreateManyRandom(stackSize);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
@@ -17,7 +17,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -32,7 +32,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
             var randomIndex = this.random.Next(0, size);
             var items = this.itemFactory.CreateMany(stackSize + 1);
@@ -49,7 +49,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -64,7 +64,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -79,7 +79,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -97,7 +97,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -120,7 +120,7 @@
         public void Replace_EmptySlot_ReplacesItemsInSlot()
         {
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);
@@ -134,7 +134,7 @@
         public void Replace_EmptySlot_ReturnsEmptyArray()
         {
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);
@@ -148,7 +148,7 @@
         public void Replace_EmptySlot_CallsOnReplaceEvent()
         {
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllFrom.cs
@@ -31,7 +31,7 @@
         [Test]
         public void GetAllFrom_SlotWithItems_ReturnItems()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
@@ -48,7 +48,7 @@
         [Test]
         public void GetAllFrom_SlotWithItems_RemovesAllItemsFromSlot()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
@@ -66,7 +66,7 @@
         [Test]
         public void GetAllFrom_SlotWithItems_CallsOnGetEvent()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllFrom.cs
@@ -5,7 +5,7 @@
         [Test]
         public void GetAllFrom_EmptySlot_ReturnsEmptyArray()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var items = inventory.GetAll(0);
             Assert.That(items, Is.Empty);
         }
@@ -13,7 +13,7 @@
         [Test]
         public void GetAllFrom_EmptySlot_DoesNotCallOnGetEvent()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called for empty slot");
             
@@ -24,7 +24,7 @@
         [TestCase(100)]
         public void GetAllFrom_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.GetAll(index), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
@@ -34,7 +34,7 @@
             var index = this.random.Next(0, 20);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var items = inventory.GetAll(index);
 
@@ -51,7 +51,7 @@
             var index = this.random.Next(0, 20);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             inventory.GetAll(index);
 
@@ -69,7 +69,7 @@
             var index = this.random.Next(0, 20);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var raised = false;
             inventory.OnGet += (sender, args) =>

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllItems.cs
@@ -32,7 +32,7 @@
         [Test]
         public void GetAllItems_InventoryWithItems_ReturnSearchedItems()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var item = this.itemFactory.CreateDefault();
             var inventoryItems = this.itemFactory.CreateManyRandom(inventorySize / 2)
@@ -53,7 +53,7 @@
         [Test]
         public void GetAllItems_InventoryWithItems_RemovesItemsFromInventory()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItems = this.itemFactory.CreateMany(inventorySize / 2);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);
@@ -71,7 +71,7 @@
         [Test]
         public void GetAllItems_InventoryWithItems_CallsOnGetEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItems = this.itemFactory.CreateMany(inventorySize / 2);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAllItems.cs
@@ -5,7 +5,7 @@
         [Test]
         public void GetAllItems_InvalidItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.GetAll(default(T)!), Throws.ArgumentNullException);
         }
 
@@ -13,7 +13,7 @@
         public void GetAllItems_EmptyInventory_ReturnsEmptyArray()
         {
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var items = inventory.GetAll(item);
             Assert.That(items, Is.Empty);
         }
@@ -22,7 +22,7 @@
         public void GetAllItems_EmptyInventory_DoesNotCallOnGetEvent()
         {
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called when no item is found");
             
@@ -39,7 +39,7 @@
                 .Append(item)
                 .Append(item)
                 .ToArray();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
 
             var items = inventory.GetAll(item);
 
@@ -58,7 +58,7 @@
             var slotItems = this.itemFactory.CreateMany(inventorySize / 2);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);
             var inventoryItems = slotItems.Concat(randomItems).ToArray();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
 
             inventory.GetAll(slotItems[0]);
 
@@ -76,7 +76,7 @@
             var slotItems = this.itemFactory.CreateMany(inventorySize / 2);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);
             var inventoryItems = slotItems.Concat(randomItems).ToArray();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
 
             var raised = false;
             inventory.OnGet += (sender, args) =>

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmount.cs
@@ -7,7 +7,7 @@
         public void GetAmount_InvalidAmount_ThrowsArgumentOutOfRangeException(int amount)
         {
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(
                 () => inventory.Get(item, amount), 
                 Throws.InstanceOf<ArgumentOutOfRangeException>()
@@ -17,7 +17,7 @@
         [Test]
         public void GetAmount_InvalidItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(
                 () => inventory.Get(default(T)!, 10), 
                 Throws.InstanceOf<ArgumentNullException>()
@@ -28,7 +28,7 @@
         public void GetAmount_EmptyInventory_ReturnsEmptyArray()
         {
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var amount = inventory.Get(item, 10);
             Assert.That(amount, Is.Empty);
         }
@@ -37,7 +37,7 @@
         public void GetAmount_EmptyInventory_DoesNotCallOnGetEvent()
         {
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called when no item is found");
             
@@ -54,7 +54,7 @@
                 .Append(item)
                 .Append(item)
                 .ToArray();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems);
 
             var items = inventory.Get(item, stackSize);
 
@@ -71,7 +71,7 @@
             var inventorySize = this.random.Next(10, 20);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
 
             inventory.Get(slotItem, stackSize);
 
@@ -84,7 +84,7 @@
             var inventorySize = this.random.Next(10, 20);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
 
             var raised = false;
             inventory.OnGet += (sender, args) => {
@@ -108,7 +108,7 @@
             var inventorySize = this.random.Next(10, 20);
             var stackSize = this.random.Next(3, 20);
             var slotItem = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
 
             inventory.Get(slotItem, stackSize + (stackSize - 2));
             
@@ -125,7 +125,7 @@
             var inventorySize = this.random.Next(10, 20);
             var stackSize = this.random.Next(3, 20);
             var slotItem = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
 
             var raised = false;
             inventory.OnGet += (sender, args) => {

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmount.cs
@@ -47,7 +47,7 @@
         [Test]
         public void GetAmount_InventoryWithItems_ReturnsSearchedItems()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var item = this.itemFactory.CreateDefault();
             var inventoryItems = this.itemFactory.CreateManyRandom(inventorySize / 2)
@@ -68,7 +68,7 @@
         [Test]
         public void GetAmount_InventoryWithItems_RemovesItemsFromSlot()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
@@ -81,7 +81,7 @@
         [Test]
         public void GetAmount_InventoryWithItems_CallsOnGetEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
@@ -105,7 +105,7 @@
         [Test]
         public void GetAmount_InventoryWithItems_RemovesItemsFromMultipleSlotsInOrder()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(3, 20);
             var slotItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
@@ -122,7 +122,7 @@
         [Test]
         public void GetAmount_InventoryWithItems_CallsOnGetEventFromMultipleSlotsInOrder()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(3, 20);
             var slotItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmountFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmountFrom.cs
@@ -41,7 +41,7 @@
         [Test]
         public void GetAmountFrom_SlotWithItems_ReturnsItems()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var stackSize = this.random.Next(10, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
@@ -56,7 +56,7 @@
         [Test]
         public void GetAmountFrom_SlotWithItems_RemovesItemsFromSlot()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var stackSize = this.random.Next(10, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
@@ -74,7 +74,7 @@
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var amount = this.random.Next(1, stackSize);
 
             var raised = false;
@@ -102,7 +102,7 @@
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var amount = this.random.Next(stackSize + 1, stackSize * 2);
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var items = inventory.Get(index, amount);
 
             Assert.That(items.Count, Is.EqualTo(stackSize));
@@ -115,7 +115,7 @@
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var amount = this.random.Next(stackSize + 1, stackSize * 2);
             inventory.Get(index, amount);
 
@@ -129,7 +129,7 @@
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
             
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var amount = this.random.Next(stackSize + 1, stackSize * 2);
 
             var raised = false;

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmountFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetAmountFrom.cs
@@ -6,7 +6,7 @@
         [TestCase(100)]
         public void GetAmountFrom_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.Get(index, 10), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
@@ -14,14 +14,14 @@
         [TestCase(0)]
         public void GetAmountFrom_InvalidAmount_ThrowsArgumentOutOfRangeException(int amount)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.Get(0, amount), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
         [Test]
         public void GetAmountFrom_EmptySlot_ReturnsEmptyArray()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             
             var item = inventory.Get(0, 10);
             
@@ -31,7 +31,7 @@
         [Test]
         public void GetAmountFrom_EmptySlot_CallsOnGetEvent()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called when no item is found");
             
@@ -44,7 +44,7 @@
             var index = this.random.Next(0, 20);
             var stackSize = this.random.Next(10, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var items = inventory.Get(index, 10);
 
@@ -59,7 +59,7 @@
             var index = this.random.Next(0, 20);
             var stackSize = this.random.Next(10, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var removeAmount = this.random.Next(1, stackSize);
             inventory.Get(index, removeAmount);
@@ -72,7 +72,7 @@
         {
             var stackSize = this.random.Next(10, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var index = this.random.Next(0, 20);
             var amount = this.random.Next(1, stackSize);
@@ -99,7 +99,7 @@
         {
             var stackSize = this.random.Next(1, 10);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var amount = this.random.Next(stackSize + 1, stackSize * 2);
             var index = this.random.Next(0, 20);
@@ -113,7 +113,7 @@
         {
             var stackSize = this.random.Next(1, 10);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var index = this.random.Next(0, 20);
             var amount = this.random.Next(stackSize + 1, stackSize * 2);
@@ -127,7 +127,7 @@
         {
             var stackSize = this.random.Next(1, 10);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
             
             var index = this.random.Next(0, 20);
             var amount = this.random.Next(stackSize + 1, stackSize * 2);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetCount.cs
@@ -5,7 +5,7 @@
         [Test]
         public void GetCount_InvalidItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             Assert.That(() => inventory.GetCount(default!), Throws.ArgumentNullException);
         }
@@ -13,7 +13,7 @@
         [Test]
         public void GetCount_EmptyInventory_ReturnsZero()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var item = this.itemFactory.CreateDefault();
 
             var count = inventory.GetCount(item);
@@ -31,7 +31,7 @@
                 .Append(item)
                 .ToList();
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
 
             var count = inventory.GetCount(item);
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
@@ -6,14 +6,14 @@
         [TestCase(100)]
         public void GetFrom_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.Get(index), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
         [Test]
         public void GetFrom_EmptySlot_ReturnsNull()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var item = inventory.Get(0);
             Assert.That(item, Is.Null);
         }
@@ -21,7 +21,7 @@
         [Test]
         public void GetFrom_EmptySlot_DoesNotCallOnGetEvent()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called when no item is found");
             
@@ -34,7 +34,7 @@
             var index = this.random.Next(0, 20);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var item = inventory.Get(index);
 
@@ -47,7 +47,7 @@
             var index = this.random.Next(0, 20);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             inventory.Get(index);
 
@@ -59,7 +59,7 @@
         {
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var index = this.random.Next(0, 20);
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
@@ -31,7 +31,7 @@
         [Test]
         public void GetFrom_SlotWithItems_ReturnsItem()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
@@ -44,7 +44,7 @@
         [Test]
         public void GetFrom_SlotWithItems_RemovesItemFromSlot()
         {
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
@@ -61,7 +61,7 @@
             var slotItem = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
-            var index = this.random.Next(0, 20);
+            var index = this.random.Next(0, MAX_SIZE_TEST);
 
             var raised = false;
             inventory.OnGet += (sender, args) => {

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
@@ -5,7 +5,7 @@
         [Test]
         public void GetItem_InvalidItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             Assert.That(() => inventory.Get(default(T)!), Throws.ArgumentNullException);
         }
@@ -14,7 +14,7 @@
         public void GetItem_EmptyInventory_ReturnsNull()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var foundItem = inventory.Get(item);
             
@@ -24,7 +24,7 @@
         [Test]
         public void GetItem_EmptyInventory_DoesNotCallOnGetEvent()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called when no item is found");
             var item = this.itemFactory.CreateDefault();
             inventory.Get(item);
@@ -35,7 +35,7 @@
         {
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var item = inventory.Get(slotItem);
 
@@ -47,7 +47,7 @@
         {
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             inventory.Get(slotItem);
 
@@ -59,7 +59,7 @@
         {
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var raised = false;
             inventory.OnGet += (sender, args) =>
@@ -84,7 +84,7 @@
         {
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             var item = this.itemFactory.CreateDefault();
             var result = inventory.Get(item);
@@ -97,7 +97,7 @@
         {
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
 
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called when no item is found");
             var item = this.itemFactory.CreateDefault();

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItems.cs
@@ -5,7 +5,7 @@
         [Test]
         public void GetItems_WhenAmountIsZeroOrSmaller_ThrowsArgumentOutOfRangeException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var item = this.itemFactory.CreateDefault();
 
             Assert.That(() => inventory.Get(item, 0), Throws.TypeOf(typeof(ArgumentOutOfRangeException)));
@@ -14,7 +14,7 @@
         [Test]
         public void GetItems_InvalidItem_ThrowsArgumentNullException()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             Assert.That(() => inventory.Get(default(T)!, 1), Throws.ArgumentNullException);
         }
@@ -23,7 +23,7 @@
         public void GetItems_ItemNotFound_ReturnsEmptyArray()
         {
             var item = this.itemFactory.CreateDefault();
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var items = inventory.Get(item, 1);
 
@@ -33,7 +33,7 @@
         [Test]
         public void GetItems_ItemNotFound_DoesNotCallOnGetEvent()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var item = this.itemFactory.CreateDefault();
             
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called when no item is found");
@@ -49,7 +49,7 @@
             var inventoryItems = this.itemFactory.CreateManyRandom(10).ToList();
             inventoryItems.AddRange(items);
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
 
             var expectedItem = items[0];
             var result = inventory.Get(expectedItem, amount);
@@ -66,7 +66,7 @@
             var inventoryItems = this.itemFactory.CreateManyRandom(10)
                 .Append(item)
                 .ToList();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
 
             inventory.Get(item, stackSize);
 
@@ -81,7 +81,7 @@
             var inventoryItems = this.itemFactory.CreateManyRandom(10)
                 .Append(item)
                 .ToList();
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
             
             var raised = false;
             inventory.OnGet += (sender, args) =>
@@ -109,7 +109,7 @@
                 .Append(item)
                 .ToList();
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
             var result = inventory.Get(item, 100);
 
             Assert.That(result, Has.Length.EqualTo(stackSize));
@@ -125,7 +125,7 @@
                 .Append(item)
                 .ToList();
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(20, stackSize, inventoryItems.ToArray());
             inventory.OnGet += (sender, args) =>
             {
                 Assert.Multiple(() =>

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Move.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Move.cs
@@ -6,7 +6,7 @@
         [TestCase(100)]
         public void Move_InvalidOriginIndex_ThrowsArgumentOutOfRangeException(int origin)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             var wasRaised = false;
             inventory.OnMove += (sender, args) => wasRaised = true;
             Assert.Multiple(() =>
@@ -25,7 +25,7 @@
         [TestCase(100)]
         public void Move_InvalidTargetIndex_ThrowsArgumentOutOfRangeException(int target)
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var wasRaised = false;
             inventory.OnMove += (sender, args) => wasRaised = true;
@@ -49,7 +49,7 @@
             var stackSize = this.random.Next(1, 20);
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
-            var inventory = this.containerFactory.EmptyContainer(inventorySize, stackSize);
+            var inventory = this.inventoryFactory.EmptyContainer(inventorySize, stackSize);
             inventory.GetAll(targetIndex);
             inventory.GetAll(originIndex);
 
@@ -62,7 +62,7 @@
             var inventorySize = this.random.Next(10, 20);
             var stackSize = this.random.Next(1, 20);
             var originIndex = this.random.Next(0, inventorySize - 1);
-            var inventory = this.containerFactory.EmptyContainer(inventorySize, stackSize);
+            var inventory = this.inventoryFactory.EmptyContainer(inventorySize, stackSize);
 
             inventory.OnMove += (sender, args) => Assert.Fail("OnMove event should not be raised on exception.");
             inventory.Move(originIndex, originIndex);
@@ -78,7 +78,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
             inventory.GetAll(originIndex);
             var targetItems = inventory.GetItems(targetIndex);
 
@@ -100,7 +100,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
             inventory.GetAll(originIndex);
             var targetItems = inventory.GetItems(targetIndex);
 
@@ -135,7 +135,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(inventorySize, stackSize, inventoryItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(inventorySize, stackSize, inventoryItems);
             inventory.GetAll(targetIndex);
             var originItems = inventory.GetItems(originIndex);
 
@@ -157,7 +157,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, randomItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, randomItem);
             inventory.GetAll(targetIndex);
             var originItems = inventory.GetItems(originIndex);
 
@@ -190,7 +190,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
             inventory.Get(originIndex, random.Next(1, stackSize - 2));
             var originItems = inventory.GetItems(originIndex);
             var targetItems = inventory.GetItems(targetIndex);
@@ -213,7 +213,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, slotItem);
             inventory.Get(originIndex, random.Next(1, stackSize - 1));
             var originItems = inventory.GetItems(originIndex);
             var targetItems = inventory.GetItems(targetIndex);
@@ -252,7 +252,7 @@
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);
             var inventoryItems = slotItems.Concat(randomItems).ToArray();
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(inventorySize, stackSize, inventoryItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(inventorySize, stackSize, inventoryItems);
 
             var originIndex = this.random.Next(5, inventorySize - 1);
             var originItems = inventory.GetItems(originIndex);
@@ -278,7 +278,7 @@
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
 
-            var inventory = this.containerFactory.ShuffledItemsContainer(inventorySize, stackSize, randomItems);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(inventorySize, stackSize, randomItems);
             var originItems = inventory.GetItems(originIndex);
             var targetItems = inventory.GetItems(targetIndex);
             inventory.OnMove += (o, e) =>

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Move.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Move.cs
@@ -45,7 +45,7 @@
         [Test]
         public void Move_EmptyOriginAndTarget_DoesNotCallOnMoveEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var originIndex = this.random.Next(5, inventorySize - 1);
             var targetIndex = this.random.Next(0, originIndex - 1);
@@ -59,7 +59,7 @@
         [Test]
         public void Move_SameOriginAndTarget_DoesNotCallOnMoveEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var originIndex = this.random.Next(0, inventorySize - 1);
             var inventory = this.inventoryFactory.EmptyContainer(inventorySize, stackSize);
@@ -71,7 +71,7 @@
         [Test]
         public void Move_EmptyOrigin_TargetWithItems_MovesItem()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
@@ -93,7 +93,7 @@
         [Test]
         public void Move_EmptyOrigin_TargetWithItems_CallsOnMoveEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
@@ -126,7 +126,7 @@
         [Test]
         public void Move_OriginWithItems_EmptyTarget_MovesItem()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItems = this.itemFactory.CreateMany(inventorySize / 2);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);
@@ -150,7 +150,7 @@
         [Test]
         public void Move_OriginWithItems_EmptyTarget_CallsOnMoveEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var randomItem = this.itemFactory.CreateRandom();
 
@@ -183,7 +183,7 @@
         [Test]
         public void Move_OriginAndTargetWithSameItems_MovesItems()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(5, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
@@ -206,7 +206,7 @@
         [Test]
         public void Move_OriginAndTargetWithSameItems_CallsOnMoveEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(2, 20);
             var slotItem = this.itemFactory.CreateDefault();
 
@@ -246,7 +246,7 @@
         [Test]
         public void Move_OriginAndTargetWithDifferentItems_MovesItemToOrigin()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var slotItems = this.itemFactory.CreateMany(inventorySize / 2);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize / 2);
@@ -271,7 +271,7 @@
         [Test]
         public void Move_OriginAndTargetWithDifferentItems_CallsOnMoveEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(1, 20);
             var randomItems = this.itemFactory.CreateManyRandom(inventorySize);
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Replace.cs
@@ -7,7 +7,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -20,7 +20,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var index = this.random.Next(0, size);
@@ -46,7 +46,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -60,7 +60,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var items = this.itemFactory.CreateMany(stackSize + 1);
@@ -77,7 +77,7 @@
         {
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
@@ -91,7 +91,7 @@
         public void CanReplace_EmptySlot_ReturnsTrue()
         {
             var stackSize = this.random.Next(10, 20);
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.Replace.cs
@@ -8,7 +8,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
 
@@ -21,7 +21,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var index = this.random.Next(0, size);
             var items = this.itemFactory
@@ -36,7 +36,7 @@
         public void CanReplace_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
         {
             var items = this.itemFactory.CreateMany(20);
-            var inventory = this.containerFactory.EmptyContainer(20);
+            var inventory = this.inventoryFactory.EmptyContainer(20);
 
             Assert.That(() => inventory.CanReplace(items, index), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
@@ -47,7 +47,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             var canReplace = inventory.CanReplace(Array.Empty<T>(), randomIndex);
@@ -61,7 +61,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var items = this.itemFactory.CreateMany(stackSize + 1);
             var index = this.random.Next(0, size);
@@ -78,7 +78,7 @@
             var item = this.itemFactory.CreateDefault();
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.FullContainer(size, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
             var newItems = this.itemFactory.CreateManyRandom(stackSize);
@@ -92,7 +92,7 @@
         {
             var stackSize = this.random.Next(10, 20);
             var size = this.random.Next(10, 20);
-            var inventory = this.containerFactory.EmptyContainer(size, stackSize);
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
             var randomIndex = this.random.Next(0, size);
             var newItems = this.itemFactory.CreateManyRandom(stackSize);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.clear.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.clear.cs
@@ -5,7 +5,7 @@
         [Test]
         public void Clear_EmptyInventory_ReturnsEmptyArray()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
 
             var result = inventory.Clear();
 
@@ -15,7 +15,7 @@
         [Test]
         public void Clear_EmptyInventory_DoesNotCallOnGetEvent()
         {
-            var inventory = this.containerFactory.EmptyContainer();
+            var inventory = this.inventoryFactory.EmptyContainer();
             inventory.OnGet += (sender, args) => Assert.Fail("OnGet event should not be called for empty inventory");
             inventory.Clear();
         }
@@ -26,7 +26,7 @@
             var inventorySize = 20;
             var stackSize = 10;
             var items = this.itemFactory.CreateManyRandom(inventorySize * stackSize);
-            var inventory = this.containerFactory.ShuffledItemsContainer(inventorySize, stackSize, items);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(inventorySize, stackSize, items);
 
             var result = inventory.Clear();
 
@@ -39,7 +39,7 @@
             var inventorySize = 20;
             var stackSize = 10;
             var items = this.itemFactory.CreateManyRandom(inventorySize * stackSize);
-            var inventory = this.containerFactory.ShuffledItemsContainer(inventorySize, stackSize, items);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(inventorySize, stackSize, items);
 
             inventory.Clear();
 
@@ -52,7 +52,7 @@
             var inventorySize = this.random.Next(10, 20);
             var stackSize = this.random.Next(10, 20);
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, item);
 
             var raised = false;
             inventory.OnGet += (sender, args) =>
@@ -73,7 +73,7 @@
             var inventorySize = 20;
             var stackSize = 10;
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, item);
 
             var expectedArraySize = inventorySize * stackSize;
             var expectedArray = new T[expectedArraySize];
@@ -90,7 +90,7 @@
             var inventorySize = 20;
             var stackSize = 10;
             var item = this.itemFactory.CreateRandom();
-            var inventory = this.containerFactory.FullContainer(inventorySize, stackSize, item);
+            var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, item);
 
             inventory.Clear();
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.clear.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.clear.cs
@@ -49,7 +49,7 @@
         [Test]
         public void Clear_InventoryWithItems_CallsOnGetEvent()
         {
-            var inventorySize = this.random.Next(10, 20);
+            var inventorySize = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(10, 20);
             var item = this.itemFactory.CreateRandom();
             var inventory = this.inventoryFactory.FullContainer(inventorySize, stackSize, item);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.cs
@@ -9,6 +9,9 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
         protected readonly IStackInventoryFactory<T> inventoryFactory;
         protected readonly ISlotItemFactory<T> itemFactory;
 
+        protected const int MIN_SIZE_TEST = 10;
+        protected const int MAX_SIZE_TEST = 20;
+
         protected IStackInventoryTests(Action<DIContainer> configure) : base(configure)
         {
             this.inventoryFactory = this.configurations.Resolve<IStackInventoryFactory<T>>();

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.cs
@@ -6,12 +6,12 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class IStackInventoryTests<T> : BaseTest<T>
     {
-        protected readonly IStackInventoryFactory<T> containerFactory;
+        protected readonly IStackInventoryFactory<T> inventoryFactory;
         protected readonly ISlotItemFactory<T> itemFactory;
 
         protected IStackInventoryTests(Action<DIContainer> configure) : base(configure)
         {
-            this.containerFactory = this.configurations.Resolve<IStackInventoryFactory<T>>();
+            this.inventoryFactory = this.configurations.Resolve<IStackInventoryFactory<T>>();
             this.itemFactory = this.configurations.Resolve<ISlotItemFactory<T>>();
         }
     }


### PR DESCRIPTION
### Motivation

- Centralize test dependencies and eliminate direct `containerFactory` fields by resolving factories from the test DI container. 
- Make `StackInventoryTests<T>` a concrete test fixture for multiple item types and wire DI registrations for the tested implementations. 

### Description

- Added a new base test partial class `IStackInventoryTests<T>` in `IStackInventoryTests.cs` that resolves `IStackInventoryFactory<T>` and `ISlotItemFactory<T>` from the DI container and inherits from `BaseTest<T>`. 
- Replaced usages of the old `containerFactory` with the resolved `inventoryFactory` across all `StackInventoryTests` files. 
- Converted `StackInventoryTests<T>` to inherit from `IStackInventoryTests<T>`, added `[TestFixture]` attributes for `TestItem`, `TestStructItem`, and `TestEnumItem`, and moved factory registrations into the test constructor to register `IStackInventoryFactory`, `IInventoryStackSlotFactory` and `ISlotItemFactory` implementations. 
- Added and updated necessary `using` directives and test factory registrations in `StackInventoryTests.cs` to wire concrete implementations used by the tests. 

### Testing

- Executed the unit test suite for `TheChest.Inventories.Tests` (the modified test files) locally; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68f54412c83238eace9910adbbea6)