### PR TITLE
Adjust tests to handle value/reference generic types and standardize size constants

### DIFF
--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItem.cs
@@ -1,11 +1,13 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class IInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItem_NotFoundItem_ReturnsNull()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var items = this.itemFactory.CreateMany(size / 2);
             var inventory = this.inventoryFactory.ShuffledItemsContainer(size, items);
 
@@ -16,9 +18,23 @@
         }
 
         [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void GetItem_NotFoundItemValueType_ReturnsDefault()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var items = this.itemFactory.CreateMany(size / 2);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, items);
+
+            var searchItem = this.itemFactory.CreateRandom();
+            var result = inventory.Get(searchItem);
+
+            Assert.That(result, Is.EqualTo(default(T)));
+        }
+
+        [Test]
         public void GetItem_ExistingItems_ReturnsFirstFoundItem()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, item);
 

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItemByIndex.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItemByIndex.cs
@@ -1,3 +1,4 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class IInventoryTests<T>
@@ -5,7 +6,7 @@
         [Test]
         public void GetItemByIndex_ValidIndexFullSlot_ReturnsItem()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, item);
 
@@ -16,15 +17,29 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItemByIndex_ValidIndexEmptySlot_ReturnsNull()
         {
-            var size = this.random.Next(10, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(size);
 
             var randomIndex = this.random.Next(0, size);
             var result = inventory.Get(randomIndex);
 
             Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void GetItemByIndex_ValidIndexEmptySlotValueType_ReturnsDefault()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            var randomIndex = this.random.Next(0, size);
+            var result = inventory.Get(randomIndex);
+
+            Assert.That(result, Is.EqualTo(default(T)));
         }
     }
 }

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.Replace.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class IInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Replace_EmptySlot_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByIndex.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByIndex.cs
@@ -1,3 +1,4 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class ILazyStackInventoryTests<T>
@@ -17,6 +18,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Get_ByIndex_EmptySlot_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -27,6 +29,20 @@
             var result = inventory.Get(randomIndex);
 
             Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void Get_ByIndex_EmptySlotValueType_ReturnsDefault()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var randomIndex = this.random.Next(0, size - 1);
+            var result = inventory.Get(randomIndex);
+
+            Assert.That(result, Is.EqualTo(default(T)));
         }
     }
 }

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByItem.cs
@@ -1,3 +1,4 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class ILazyStackInventoryTests<T>
@@ -17,6 +18,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Get_ByItem_NotFoundItem_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -28,6 +30,21 @@
             var result = inventory.Get(item);
 
             Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void Get_ByItem_NotFoundItemValueType_ReturnsDefault()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var items = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, stackSize, items);
+
+            var item = this.itemFactory.CreateRandom();
+            var result = inventory.Get(item);
+
+            Assert.That(result, Is.EqualTo(default(T)));
         }
     }
 }

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
@@ -1,3 +1,4 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class IStackInventoryTests<T>
@@ -10,7 +11,7 @@
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
-            var items = this.itemFactory.CreateMany(20);
+            var items = this.itemFactory.CreateMany(stackSize);
             Assert.That(() => inventory.Replace(items, index), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
 
@@ -44,6 +45,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Replace_NullItems_DoesNotReplace()
         {
             var item = this.itemFactory.CreateDefault();

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class IStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetFrom_EmptySlot_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -12,6 +14,19 @@
             var item = inventory.Get(index);
             
             Assert.That(item, Is.Null);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void GetFrom_EmptySlotValueType_ReturnsDefault()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            var index = this.random.Next(0, size);
+            var item = inventory.Get(index);
+
+            Assert.That(item, Is.EqualTo(default(T)));
         }
 
         [Test]

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Interfaces
 {
     public partial class IStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItem_EmptyInventory_ReturnsNull()
         {
             var item = this.itemFactory.CreateDefault();
@@ -11,6 +13,18 @@
             var foundItem = inventory.Get(item);
             
             Assert.That(foundItem, Is.Null);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void GetItem_EmptyInventoryValueType_ReturnsDefault()
+        {
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            var foundItem = inventory.Get(item);
+
+            Assert.That(foundItem, Is.EqualTo(default(T)));
         }
 
         [Test]
@@ -27,16 +41,33 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItem_InventoryWithDifferentItems_ReturnsNull()
         {
-            var stackSize = this.random.Next(1, 20);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slotItem = this.itemFactory.CreateRandom();
-            var inventory = this.inventoryFactory.FullContainer(20, stackSize, slotItem);
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, slotItem);
 
             var item = this.itemFactory.CreateDefault();
             var result = inventory.Get(item);
 
             Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void GetItem_InventoryWithDifferentItemsValueType_ReturnsDefault()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItem = this.itemFactory.CreateRandom();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, slotItem);
+
+            var item = this.itemFactory.CreateDefault();
+            var result = inventory.Get(item);
+
+            Assert.That(result, Is.EqualTo(default(T)));
         }
     }
 }

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddAt.cs
@@ -1,5 +1,6 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
@@ -18,6 +19,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddAt_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItem.cs
@@ -2,11 +2,13 @@
 using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItems.cs
@@ -1,6 +1,7 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
@@ -18,6 +19,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayWithOnlyNullItems_ReturnsEmptyArray()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -30,6 +32,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayWithOnlyNullItems_DoesNotAddToAnySlot()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -42,6 +45,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayWithOnlyNullItems_DoesNotCallOnAddEvent()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -52,6 +56,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_ReturnsEmptyArray()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -68,6 +73,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_DoesNotAddNullToAnySlot()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -89,6 +95,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_DoesNotCallOnAddEventWithNullItems()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -112,6 +119,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_CallsOnAddEventWithAddedItems()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItem.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItemAt.cs
@@ -1,10 +1,12 @@
 ﻿using NUnit.Framework.Internal;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddAt_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItems.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItems_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
@@ -10,6 +12,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItems_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetAll.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetAll.cs
@@ -1,10 +1,12 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetAll_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItem.cs
@@ -1,14 +1,25 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
             Assert.That(() => inventory.Get(item: default!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void GetItem_DefaultValueTypeItem_DoesNotThrow()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            Assert.That(() => inventory.Get(item: default!), Throws.Nothing);
         }
 
         [Test]

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItemCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItemCount.cs
@@ -1,10 +1,12 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetCount_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItems.cs
@@ -1,3 +1,4 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
@@ -17,6 +18,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItems_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.Replace.cs
@@ -1,5 +1,6 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
@@ -17,6 +18,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Replace_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAmount.cs
@@ -2,11 +2,13 @@
 using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Add_WithAmount_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAt.cs
@@ -1,11 +1,13 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddAt_NullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddOne.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddOne.cs
@@ -2,11 +2,13 @@
 using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Add_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAdd.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAdd.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAdd_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAddAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAddAt.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddAt_NullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanReplace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanReplace.cs
@@ -1,3 +1,4 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
@@ -33,6 +34,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanReplace_NullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetAllByItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetAllByItem.cs
@@ -1,10 +1,12 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetAllByItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItem.cs
@@ -1,14 +1,25 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Get_ByItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
             Assert.Throws<ArgumentNullException>(() => inventory.Get(item: default!));
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void Get_ByItem_DefaultValueTypeItem_DoesNotThrow()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            Assert.That(() => inventory.Get(item: default!), Throws.Nothing);
         }
 
         [Test]

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItemAndAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItemAndAmount.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Get_ByItemAndAmount_Nulltem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetCount.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetCount_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.Replace.cs
@@ -1,6 +1,7 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
 {
     public partial class LazyStackInventoryTests<T>
@@ -132,6 +133,7 @@ namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void Replace_EmptySlot_CallsOnReplaceEventWithNullOldItem()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.AddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.AddItemAt.cs
@@ -1,5 +1,6 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
@@ -20,6 +21,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void AddItemAt_InvalidItem_ThrowsArgumentException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItem.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemAt.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItemAt_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItems.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItems_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
@@ -10,6 +12,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItems_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemsAt.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItemsAt_NullItems_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -13,6 +15,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanAddItemsAt_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAllItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAllItems.cs
@@ -1,11 +1,13 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetAllItems_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAmount.cs
@@ -1,5 +1,6 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
@@ -15,6 +16,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetAmount_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetCount.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetCount_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItem.cs
@@ -1,15 +1,26 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItem_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
 
             Assert.That(() => inventory.Get(default(T)!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        [IgnoreIfReferenceTypeAttribute]
+        public void GetItem_DefaultValueTypeItem_DoesNotThrow()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            Assert.That(() => inventory.Get(default(T)!), Throws.Nothing);
         }
 
         [Test]

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItems.cs
@@ -1,6 +1,7 @@
 ﻿using TheChest.Tests.Common.Extensions.Containers;
 using TheChest.Tests.Common.Extensions.Slots;
 
+using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
@@ -15,6 +16,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void GetItems_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.Replace.cs
@@ -1,8 +1,10 @@
+using TheChest.Tests.Common.Attributes;
 ﻿namespace TheChest.Inventories.Tests.Containers.StackInventory
 {
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanReplace_NullItems_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -16,6 +18,7 @@
         }
 
         [Test]
+        [IgnoreIfValueTypeAttribute]
         public void CanReplace_ItemsContainingNull_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);


### PR DESCRIPTION
### Motivation
- Tests must behave correctly for both value and reference generic item types and avoid false failures when `T` is a value type or a reference type.
- Several tests used hard-coded size ranges which should be consistent across the suite.

### Description
- Added `using TheChest.Tests.Common.Attributes;` and decorated tests with conditional attributes `IgnoreIfValueTypeAttribute` and `IgnoreIfReferenceTypeAttribute` to skip or include tests appropriately based on `T` being a value or reference type.
- Introduced and used shared size constants (`MIN_SIZE_TEST`, `MAX_SIZE_TEST`, `MIN_STACK_SIZE_TEST`, `MAX_STACK_SIZE_TEST`) in place of hard-coded `random.Next(10,20)` and other literals to standardize test sizes.
- Added new test cases to assert default(T) behavior for value types when items/slots are not present and adjusted existing null-check expectations accordingly.
- Fixed an items count in one test from a hard-coded value to `stackSize` to ensure correct validation against stack capacities.

### Testing
- Ran the `TheChest.Inventories.Tests` unit test suite covering modified files under `tests/TheChest.Inventories.Tests`; the suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4243f5dfc8323abeb6203a7ae6a88)