### PR TITLE
test: skip null-specific container tests for value-type fixtures

### DIFF
--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItem.cs
@@ -3,6 +3,7 @@
     public partial class IInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItem_NotFoundItem_ReturnsNull()
         {
             var size = this.random.Next(10, 20);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItemByIndex.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.GetItemByIndex.cs
@@ -16,6 +16,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItemByIndex_ValidIndexEmptySlot_ReturnsNull()
         {
             var size = this.random.Next(10, 20);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IInventory/IInventoryTests.Replace.cs
@@ -3,6 +3,7 @@
     public partial class IInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Replace_EmptySlot_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByIndex.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByIndex.cs
@@ -17,6 +17,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Get_ByIndex_EmptySlot_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/ILazyStackInventory/ILazyStackInventoryTests.GetByItem.cs
@@ -17,6 +17,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Get_ByItem_NotFoundItem_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanReplace.cs
@@ -44,6 +44,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Replace_NullItems_DoesNotReplace()
         {
             var item = this.itemFactory.CreateDefault();

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetFrom.cs
@@ -3,6 +3,7 @@
     public partial class IStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetFrom_EmptySlot_ReturnsNull()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.GetItem.cs
@@ -3,6 +3,7 @@
     public partial class IStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItem_EmptyInventory_ReturnsNull()
         {
             var item = this.itemFactory.CreateDefault();
@@ -27,6 +28,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItem_InventoryWithDifferentItems_ReturnsNull()
         {
             var stackSize = this.random.Next(1, 20);

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddAt.cs
@@ -18,6 +18,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddAt_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItem.cs
@@ -7,6 +7,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
     public partial class InventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.AddItems.cs
@@ -18,6 +18,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayWithOnlyNullItems_ReturnsEmptyArray()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -30,6 +31,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayWithOnlyNullItems_DoesNotAddToAnySlot()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -42,6 +44,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayWithOnlyNullItems_DoesNotCallOnAddEvent()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -52,6 +55,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_ReturnsEmptyArray()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -68,6 +72,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_DoesNotAddNullToAnySlot()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -89,6 +94,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_DoesNotCallOnAddEventWithNullItems()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -112,6 +118,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItems_ArrayContainingNullItems_CallsOnAddEventWithAddedItems()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItem.cs
@@ -3,6 +3,7 @@
     public partial class InventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItemAt.cs
@@ -5,6 +5,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
     public partial class InventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddAt_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.CanAddItems.cs
@@ -3,6 +3,7 @@
     public partial class InventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItems_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
@@ -10,6 +11,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItems_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetAll.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetAll.cs
@@ -5,6 +5,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
     public partial class InventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetAll_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItem.cs
@@ -5,6 +5,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
     public partial class InventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItemCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItemCount.cs
@@ -5,6 +5,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
     public partial class InventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetCount_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.GetItems.cs
@@ -17,6 +17,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItems_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/Inventory/InventoryTests.Replace.cs
@@ -17,6 +17,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Replace_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAmount.cs
@@ -7,6 +7,7 @@ namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Add_WithAmount_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddAt.cs
@@ -6,6 +6,7 @@ namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddAt_NullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddOne.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.AddOne.cs
@@ -7,6 +7,7 @@ namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Add_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAdd.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAdd.cs
@@ -3,6 +3,7 @@
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAdd_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAddAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanAddAt.cs
@@ -3,6 +3,7 @@
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddAt_NullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanReplace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.CanReplace.cs
@@ -33,6 +33,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanReplace_NullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetAllByItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetAllByItem.cs
@@ -5,6 +5,7 @@ namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetAllByItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItem.cs
@@ -5,6 +5,7 @@ namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Get_ByItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItemAndAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetByItemAndAmount.cs
@@ -3,6 +3,7 @@
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Get_ByItemAndAmount_Nulltem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.GetCount.cs
@@ -3,6 +3,7 @@
     public partial class LazyStackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetCount_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/LazyStackInventory/LazyStackInventoryTests.Replace.cs
@@ -132,6 +132,7 @@ namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void Replace_EmptySlot_CallsOnReplaceEventWithNullOldItem()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.AddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.AddItemAt.cs
@@ -20,6 +20,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void AddItemAt_InvalidItem_ThrowsArgumentException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItem.cs
@@ -3,6 +3,7 @@
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemAt.cs
@@ -3,6 +3,7 @@
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItemAt_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItems.cs
@@ -3,6 +3,7 @@
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItems_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
@@ -10,6 +11,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItems_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemsAt.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.CanAddItemsAt.cs
@@ -3,6 +3,7 @@
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItemsAt_NullItems_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -13,6 +14,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanAddItemsAt_ArrayContainingNullItem_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAllItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAllItems.cs
@@ -6,6 +6,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetAllItems_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAmount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetAmount.cs
@@ -15,6 +15,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetAmount_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetCount.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetCount.cs
@@ -3,6 +3,7 @@
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetCount_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItem.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItem.cs
@@ -5,6 +5,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItem_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItems.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.GetItems.cs
@@ -15,6 +15,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void GetItems_InvalidItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.Replace.cs
+++ b/tests/TheChest.Inventories.Tests/Containers/StackInventory/StackInventoryTests.Replace.cs
@@ -3,6 +3,7 @@
     public partial class StackInventoryTests<T>
     {
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanReplace_NullItems_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -16,6 +17,7 @@
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]
         public void CanReplace_ItemsContainingNull_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);


### PR DESCRIPTION
### Motivation
- Some container tests assert `null` behavior or expect `ArgumentNullException` for `null` inputs which do not apply to value-type fixtures (`struct`/`enum`) and cause spurious failures when run with value-type item types.

### Description
- Added the attribute `[TheChest.Tests.Common.Attributes.IgnoreIfValueTypeAttribute]` to null-specific tests across `Inventory`, `StackInventory`, `LazyStackInventory`, and shared interface test suites so those tests are skipped for value-type fixtures.
- Changes only affect test annotations and do not modify production code or test logic for reference-type fixtures.
- The changes were applied consistently to tests that use `default!`/`null` expectations or assert `null` return values.

### Testing
- Attempted to run the test suite with `dotnet test TheChest.Inventories.sln` but it could not be executed because `dotnet` is not available in the execution environment (so full test run was not performed).
- Verified the edits with automated file-search commands such as `rg -n "IgnoreIfValueTypeAttribute" tests/TheChest.Inventories.Tests/Containers` to confirm the attribute was inserted across the targeted test files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4243f5dfc8323abeb6203a7ae6a88)