### PR TITLE
Fix Inventory.Move when origin slot is empty

### DIFF
--- a/src/Containers/Inventory.cs
+++ b/src/Containers/Inventory.cs
@@ -426,17 +426,20 @@ namespace TheChest.Inventories.Containers
             if (target < 0 || target >= this.Size)
                 throw new ArgumentOutOfRangeException(nameof(target));
 
-            var item = this.slots[origin].Get();
-            var oldItem = this.slots[target].Replace(item);
+            var originItem = this.slots[origin].Get();
+            var targetItem = this.slots[target].Get();
 
             var events = new List<InventoryMoveItemEventData<T>>();
-            if (!EqualityComparer<T>.Default.Equals(item, default))
-                events.Add(new InventoryMoveItemEventData<T>(item, origin, target));
-
-            if (!EqualityComparer<T>.Default.Equals(oldItem, default))
+            if (!EqualityComparer<T>.Default.Equals(originItem, default))
             {
-                this.slots[origin].Replace(oldItem);
-                events.Add(new InventoryMoveItemEventData<T>(oldItem, target, origin));
+                this.slots[target].Add(originItem);
+                events.Add(new InventoryMoveItemEventData<T>(originItem, origin, target));
+            }
+
+            if (!EqualityComparer<T>.Default.Equals(targetItem, default))
+            {
+                this.slots[origin].Add(targetItem);
+                events.Add(new InventoryMoveItemEventData<T>(targetItem, target, origin));
             }
             this.OnMove?.Invoke(this, new InventoryMoveEventArgs<T>(events.ToArray()));
         }


### PR DESCRIPTION
### Motivation
- `Inventory<T>.Move` threw an `ArgumentNullException` when the origin slot was empty but the target slot contained an item, due to calling `Replace(null)` on a slot. 
- The intent is to move/swap items between two slots and emit move events only for actual item movements while preserving slot semantics.

### Description
- Rewrote `Move(int origin, int target)` to read both slot values first using `Get()` and then re-add non-empty values with `Add()` instead of calling `Replace()` with possible nulls. 
- Emits one `InventoryMoveItemEventData<T>` per non-empty item actually moved with correct source and destination indices. 
- Removed the previous `Replace`-based swap that caused `Replace(null)` to be invoked when origin was empty. 
- Change located in `src/Containers/Inventory.cs` (the `Move` method). 

### Testing
- Ran `dotnet test -v minimal`; before the change the test run showed 2 failing tests due to `ArgumentNullException` in `InventorySlot.Replace`. 
- After the change ran `dotnet test -v minimal` again and all automated tests passed: 595 passed, 10 skipped, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e66c409483238738053294767ade)