### PR TITLE
docs(inventory): update class diagram to match Inventory and InventorySlot API

### DIFF
--- a/docs/inventory/class_diagram.md
+++ b/docs/inventory/class_diagram.md
@@ -23,8 +23,8 @@ direction TB
 	        + ~~event~~ OnReplace: InventoryReplaceEventHandler~T~ 
 
 	        + T[] GetAll(T item)
-	        + T? Get(int index)
-	        + T? Get(T item)
+	        + T Get(int index)
+	        + T Get(T item)
 	        + T[] Get(T item, int amount)
 
 	        + T[] Clear()
@@ -51,7 +51,7 @@ direction TB
 			+ bool CanReplace(T item)
 	        + T Replace(T item)
 
-	        + T? Get()
+	        + T Get()
 	        + bool Contains(T item)
         }
         class Inventory~T~ {
@@ -78,14 +78,19 @@ direction TB
 	        + bool CanAddAt(T item, int index)
 	        + bool AddAt(T item, int index)
 
+            # bool CanAddItems(T[] items)
+            # T[] AddItems(params T[] items)
+
 	        + T[] Clear()
 
 	        + T[] GetAll(T item)
-	        + T? Get(int index)
-	        + T? Get(T item)
+	        + T Get(int index)
+	        + T Get(T item)
 	        + T[] Get(T item, int amount)
 
 	        + int GetCount(T item)
+
+            + bool CanMove(int origin, int target)
 
 	        + bool CanReplace(T item, int index)
 	        + T Replace(T item, int index)
@@ -137,23 +142,24 @@ namespace TheChest.Inventories {
         + bool CanAdd(T item)
         + bool Add(T item)
 
-        + T? Get()
+        + T Get()
 
         + bool CanReplace(T item)
         + T Replace(T item)
     }
     class InventorySlot~T~ {
-        + InventorySlot(T? currentItem = default)
+        + InventorySlot()
+        + InventorySlot(T currentItem)
 
         + bool Contains(T item)
 
         + bool CanAdd(T item)
         + bool Add(T item)
 
-        + T? Get()
+        + T Get()
 
         + bool CanReplace(T item)
-        + T? Replace(T item)
+        + T Replace(T item)
     }
 }
 


### PR DESCRIPTION
### Motivation
- Keep the class diagram in `docs/inventory/class_diagram.md` in sync with the current implementation of `Inventory<T>` and `InventorySlot<T>`.
- Reflect recently introduced helper/protected methods and the `CanMove` check so the diagram documents available behaviors.
- Correct constructor overloads and `Get`/`Replace` return signatures for `InventorySlot<T>` to match the code.

### Description
- Updated `docs/inventory/class_diagram.md` to change `Get` signatures from nullable to non-nullable (`T Get(...)`).
- Added the protected helper methods `CanAddItems(T[] items)` and `AddItems(params T[] items)` to the `Inventory<T>` diagram (marked as helpers) and added `CanMove(int origin, int target)`.
- Split `InventorySlot` constructor in the diagram into `InventorySlot()` and `InventorySlot(T currentItem)` and corrected `Get`/`Replace` return types to `T`.
- Verified the diagram entries against the implementations in `src/Containers/Inventory.cs`, `src/Slots/InventorySlot.cs`, and the related interface files before saving the change.

### Testing
- Ran repository searches with `rg` to locate relevant types and ensure diagram updates cover implemented methods, and the searches completed successfully.
- Inspected source files with `sed -n` to compare method signatures in `src/Containers/Inventory.cs`, `src/Slots/InventorySlot.cs`, `src/Containers/Interfaces/IInventory.cs`, and `src/Slots/Interfaces/IInventorySlot.cs`, and the inspections matched the diagram changes.
- Ran `rg "protected|virtual" src/Containers/Inventory.cs -n` to confirm presence of the protected helpers and the `virtual` methods, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e87b054483239a1c499cf2e97fdc)