### PR TITLE
Add unit tests for InventorySlot Add/Get/Replace behavior

### DIFF
--- a/tests/Slots/InventorySlot/InventorySlotTests.add.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.add.cs
@@ -41,5 +41,24 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
                 Throws.InvalidOperationException.With.Message.EqualTo("The slot is already full.")
             );
         }
+
+        [Test]
+        public void Add_NullItem_ThrowsArgumentNullException()
+        {
+            var slot = this.slotFactory.Empty();
+
+            Assert.That(() => slot.Add(default!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Add_EmptySlot_ReturnsTrue_WhenAddingDirectly()
+        {
+            var slot = this.slotFactory.Empty();
+            var item = this.itemFactory.CreateDefault();
+
+            var result = slot.Add(item);
+
+            Assert.That(result, Is.True);
+        }
     }
 }

--- a/tests/Slots/InventorySlot/InventorySlotTests.get.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.get.cs
@@ -14,5 +14,26 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
             Assert.That(slot.GetContent(), Is.Null);
         }
+
+        [Test]
+        public void GetOne_FullSlot_ReturnsExistingItem()
+        {
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(item);
+
+            var result = slot.Get();
+
+            Assert.That(result, Is.EqualTo(item));
+        }
+
+        [Test]
+        public void GetOne_EmptySlot_ReturnsNull()
+        {
+            var slot = this.slotFactory.Empty();
+
+            var result = slot.Get();
+
+            Assert.That(result, Is.Null);
+        }
     }
 }

--- a/tests/Slots/InventorySlot/InventorySlotTests.replace.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.replace.cs
@@ -26,5 +26,36 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
             Assert.That(slot.GetContent(), Is.Not.Null.And.EqualTo(newItem));
         }
+
+        [Test]
+        public void Replace_ReplacingItemOnEmptySlot_ReturnsNull_WhenReplacingDirectly()
+        {
+            var slot = this.slotFactory.Empty();
+            var newItem = this.itemFactory.CreateDefault();
+
+            var result = slot.Replace(newItem);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Replace_ReplacingItemOnFullSlot_ReturnsPreviousItem()
+        {
+            var existingItem = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(existingItem);
+            var newItem = this.itemFactory.CreateRandom();
+
+            var result = slot.Replace(newItem);
+
+            Assert.That(result, Is.EqualTo(existingItem));
+        }
+
+        [Test]
+        public void Replace_NullItem_ThrowsArgumentNullException()
+        {
+            var slot = this.slotFactory.Empty();
+
+            Assert.That(() => slot.Replace(default!), Throws.ArgumentNullException);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for `InventorySlot<T>` focusing on `Add`, `Get` and `Replace` behaviors.
- Ensure correct null input validation and confirm return values and slot state changes for empty and full slot scenarios.

### Description
- Added tests to `tests/Slots/InventorySlot/InventorySlotTests.add.cs` to assert null input handling and that `Add` returns `true` when adding to an empty slot.
- Added tests to `tests/Slots/InventorySlot/InventorySlotTests.get.cs` to assert that `Get` returns the existing item for a full slot and `null` for an empty slot. 
- Added tests to `tests/Slots/InventorySlot/InventorySlotTests.replace.cs` to assert `Replace` return values for empty/full slots and null input validation.

### Testing
- Ran the targeted test set with `dotnet test --filter "FullyQualifiedName~TheChest.Inventories.Tests.Slots.InventorySlot.InventorySlotTests"`. 
- Result: all matching tests passed (26 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e7d159d08323bf067d82e9ce90d9)