### PR TITLE
Inventory tests: add null/empty-item coverage and assert exception messages

### DIFF
--- a/tests/Containers/Interfaces/IInventory/IInventoryTests.AddItem.cs
+++ b/tests/Containers/Interfaces/IInventory/IInventoryTests.AddItem.cs
@@ -5,6 +5,19 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
     public partial class IInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueType]
+        public void AddItem_NullItem_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            Assert.That(
+                () => inventory.Add(item: default!),
+                Throws.ArgumentNullException
+                    .With.Message.EqualTo("Value cannot be null. (Parameter 'item')")
+            );
+        }
+
+        [Test]
         public void AddItem_EmptyInventory_ReturnsTrue()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/Containers/Interfaces/IInventory/IInventoryTests.CanAddItem.cs
+++ b/tests/Containers/Interfaces/IInventory/IInventoryTests.CanAddItem.cs
@@ -5,6 +5,19 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
     public partial class IInventoryTests<T>
     {
         [Test]
+        [IgnoreIfValueType]
+        public void CanAddItem_NullItem_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            Assert.That(
+                () => inventory.CanAdd(item: default!),
+                Throws.ArgumentNullException
+                    .With.Message.EqualTo("Value cannot be null. (Parameter 'item')")
+            );
+        }
+
+        [Test]
         public void CanAddItem_EmptyInventory_ReturnsTrue()
         {
             var inventory = this.inventoryFactory.EmptyContainer();

--- a/tests/Containers/Inventory/InventoryTests.AddItem.cs
+++ b/tests/Containers/Inventory/InventoryTests.AddItem.cs
@@ -12,7 +12,11 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         public void AddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
-            Assert.That(() => inventory.Add(item: default!), Throws.ArgumentNullException);
+            Assert.That(
+                () => inventory.Add(item: default!),
+                Throws.ArgumentNullException
+                    .With.Message.EqualTo("Value cannot be null. (Parameter 'item')")
+            );
         }
 
         [Test]

--- a/tests/Containers/Inventory/InventoryTests.AddItems.cs
+++ b/tests/Containers/Inventory/InventoryTests.AddItems.cs
@@ -20,6 +20,39 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         }
 
         [Test]
+        public void AddItems_EmptyItemsArray_ThrowsArgumentException()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            Assert.That(
+                () => inventory.Add(Array.Empty<T>()),
+                Throws.ArgumentException
+                    .With.Message.EqualTo("Cannot add an empty array of items. (Parameter 'items')")
+            );
+        }
+
+        [Test]
+        [IgnoreIfValueType]
+        public void AddItems_ArrayContainingNullItems_ThrowsArgumentNullException()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            var items = this.itemFactory
+                .CreateManyRandom(this.random.Next(2, size))
+                .Append(default!)
+                .ToArray();
+            items.Shuffle();
+
+            Assert.That(
+                () => inventory.Add(items),
+                Throws.ArgumentNullException
+                    .With.Message.EqualTo("One of the items to add is null (Parameter 'items')")
+            );
+        }
+
+        [Test]
         public void AddItems_ArrayWithOnlyNullItems_ThrowsArgumentNullException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);

--- a/tests/Containers/Inventory/InventoryTests.CanAddItem.cs
+++ b/tests/Containers/Inventory/InventoryTests.CanAddItem.cs
@@ -9,7 +9,11 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         public void CanAddItem_NullItem_ThrowsArgumentNullException()
         {
             var inventory = this.inventoryFactory.EmptyContainer();
-            Assert.That(() => inventory.CanAdd(item: default!), Throws.ArgumentNullException);
+            Assert.That(
+                () => inventory.CanAdd(item: default!),
+                Throws.ArgumentNullException
+                    .With.Message.EqualTo("Value cannot be null. (Parameter 'item')")
+            );
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure inventory implementations consistently reject `null` items and empty item arrays. 
- Verify precise argument validation by asserting exact exception messages for `Add` and `CanAdd`. 
- Cover edge cases for batch add operations including arrays containing a `null` element. 

### Description
- Added `AddItem_NullItem_ThrowsArgumentNullException` and `CanAddItem_NullItem_ThrowsArgumentNullException` tests and marked them with `IgnoreIfValueType` to skip value-type generics. 
- Added `AddItems_EmptyItemsArray_ThrowsArgumentException` and `AddItems_ArrayContainingNullItems_ThrowsArgumentNullException` tests to validate batch `Add` behavior. 
- Tightened existing exception assertions to check the `ArgumentNullException`/`ArgumentException` messages using `.With.Message.EqualTo(...)` and preserved tests that ensure no slots are modified when null-only arrays are provided. 

### Testing
- Ran the inventory unit tests under `tests/Containers/...` including the new `Add`, `AddItems`, and `CanAdd` tests. 
- All modified and existing tests executed successfully. 
- No additional integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ee9b9af08323be21fa559d48a770)