### PR TITLE
Refactor InventoryStackSlot error messages and add-exception behavior; update tests

### DIFF
--- a/src/Slots/Exceptions/InventoryStackSlotErrors.cs
+++ b/src/Slots/Exceptions/InventoryStackSlotErrors.cs
@@ -1,0 +1,17 @@
+﻿namespace TheChest.Inventories.Slots.Exceptions
+{
+    internal class InventoryStackSlotErrors
+    {
+        #region Add(T[] items)
+        internal const string CannotAddEmptyItems = "Cannot add empty list of items";
+        internal const string CannotAddArrayWithNullValues = "Cannot add an array of items with null values";
+        internal const string CannotAddArrayWithDifferentTypes = "Cannot add an array of items with different types";
+        internal const string CannotAddMoreThanAvailableAmount = "Cannot add more items than the available amount";
+        #endregion
+
+        #region Add(T[] items) & Add(T item)
+        internal const string SlotIsFull = "The slot is full";
+        internal const string CannotAddDifferentItemsFromSlot = "Cannot add items that are different from the items already in the slot";
+        #endregion
+    }
+}

--- a/src/Slots/InventoryStackSlot.cs
+++ b/src/Slots/InventoryStackSlot.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using TheChest.Core.Slots;
 using TheChest.Core.Slots.Interfaces;
 using TheChest.Inventories.Extensions;
+using TheChest.Inventories.Slots.Exceptions;
 using TheChest.Inventories.Slots.Interfaces;
 
 namespace TheChest.Inventories.Slots
@@ -138,18 +139,17 @@ namespace TheChest.Inventories.Slots
         public virtual T[] Add(T[] items)
         {
             if (items.Length == 0)
-                throw new ArgumentException("Cannot add empty list of items", nameof(items));
+                throw new ArgumentException(InventoryStackSlotErrors.CannotAddEmptyItems, nameof(items));
             if (items.ContainsNull())
-                throw new ArgumentNullException(nameof(items), "Cannot add an array of items with null values");
+                throw new ArgumentNullException(nameof(items), InventoryStackSlotErrors.CannotAddArrayWithNullValues);
             if (!items.HasAllEqual())
-                throw new ArgumentException("Cannot add an array of items with different types", nameof(items));
-            if (items.Length > this.AvailableAmount)
-                throw new ArgumentException("Cannot add more items than the available amount", nameof(items));
-
+                throw new ArgumentException(InventoryStackSlotErrors.CannotAddArrayWithDifferentTypes, nameof(items));
             if (this.IsFull)
-                throw new InvalidOperationException("The slot is full");
+                throw new InvalidOperationException(InventoryStackSlotErrors.SlotIsFull);
+            if (items.Length > this.AvailableAmount)
+                throw new InvalidOperationException(InventoryStackSlotErrors.CannotAddMoreThanAvailableAmount);
             if (!this.IsEmpty && !this.Contains(items))
-                throw new InvalidOperationException("Cannot add items that are different from the items already in the slot");
+                throw new InvalidOperationException(InventoryStackSlotErrors.CannotAddDifferentItemsFromSlot);
 
             this.AddItems(ref items);
 
@@ -162,9 +162,9 @@ namespace TheChest.Inventories.Slots
             if(item.IsNull())
                 throw new ArgumentNullException(nameof(item));
             if (this.IsFull)
-                throw new InvalidOperationException("The slot is full");
+                throw new InvalidOperationException(InventoryStackSlotErrors.SlotIsFull);
             if (!this.IsEmpty && !this.Contains(item))
-                throw new InvalidOperationException("Cannot add items that are different from the items already in the slot");
+                throw new InvalidOperationException(InventoryStackSlotErrors.CannotAddDifferentItemsFromSlot);
 
             if (this.CanAdd(item))
             {

--- a/tests/Slots/Interfaces/IInventoryStackSlot/IInventoryStackSlotTests.add_items.cs
+++ b/tests/Slots/Interfaces/IInventoryStackSlot/IInventoryStackSlotTests.add_items.cs
@@ -42,15 +42,13 @@
         }
 
         [Test]
-        public void Add_FullSlot_DoesNotIncreaseAmount()
+        public void Add_FullSlot_ThrowsInvalidOperationException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = this.itemFactory.CreateMany(stackSize);
             var slot = this.slotFactory.Full(items);
             var item = this.itemFactory.CreateDefault();
-            slot.Add(item);
-
-            Assert.That(slot.Amount, Is.EqualTo(stackSize));
+            Assert.That(() => slot.Add(item), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_item.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_item.cs
@@ -15,16 +15,14 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Add_FullSlot_DoNotAddToContent()
+        public void Add_FullSlot_ThrowsInvalidOperationException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = this.itemFactory.CreateMany(stackSize);
             var slot = this.slotFactory.Full(items);
 
             var item = this.itemFactory.CreateDefault();
-            slot.Add(item);
-
-            Assert.That(slot.GetContents(), Has.No.AnyOf(item));
+            Assert.That(() => slot.Add(item), Throws.InvalidOperationException);
         }
 
         [Test]
@@ -38,6 +36,18 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
             slot.Add(item);
 
             Assert.That(slot.GetContents(), Has.One.EqualTo(expecteditem[0]));
+        }
+
+        [Test]
+        public void Add_EmptySlot_ReturnsTrue()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+
+            var item = this.itemFactory.CreateDefault();
+            var result = slot.Add(item);
+
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -57,7 +67,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Add_SlotWithDifferentItem_DoesNotAddToContent()
+        public void Add_SlotWithDifferentItem_ThrowsInvalidOperationException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var halfStackSize = stackSize / 2;
@@ -65,9 +75,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
             var slot = this.slotFactory.WithItems(items, stackSize);
 
             var item = this.itemFactory.CreateRandom();
-            slot.Add(item);
-
-            Assert.That(slot.GetContents(), Has.None.EqualTo(item));
+            Assert.That(() => slot.Add(item), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_items.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_items.cs
@@ -20,7 +20,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_DifferentItemsFromSlot_ThrowsArgumentException()
+        public void AddItems_DifferentItemsFromSlot_WithMoreThanAvailableAmount_ThrowsInvalidOperationException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = new T[1] {  this.itemFactory.CreateRandom() };
@@ -28,7 +28,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
             var addingItems = this.itemFactory.CreateManyRandom(stackSize);
 
-            Assert.That(() => slot.Add(addingItems), Throws.ArgumentException);
+            Assert.That(() => slot.Add(addingItems), Throws.InvalidOperationException);
         }
 
         [Test]
@@ -57,31 +57,64 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_EmptySlot_WithMoreItemsThanMaxAmount_AddsAllItems()
+        public void AddItems_EmptySlot_WithMoreItemsThanMaxAmount_ThrowsInvalidOperationException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
 
             var randomSize = this.random.Next(stackSize + 1, stackSize + 20);
             var addingItems = this.itemFactory.CreateManyRandom(randomSize);
-            var expectedItems = (T[])addingItems[0..stackSize].Clone();
-            slot.Add(addingItems);
-
-            Assert.That(slot.GetContents(), Is.EqualTo(expectedItems));
+            Assert.That(() => slot.Add(addingItems), Throws.InvalidOperationException);
         }
 
 
         [Test]
-        public void Add_FullSlot_DoesNotAdd()
+        public void AddItems_FullSlot_WithMultipleItems_ThrowsInvalidOperationException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = this.itemFactory.CreateMany(stackSize);
             var slot = this.slotFactory.Full(items);
 
             var addingItems = this.itemFactory.CreateMany(stackSize);
-            slot.Add(addingItems);
+            Assert.That(() => slot.Add(addingItems), Throws.InvalidOperationException);
+        }
 
-            Assert.That(slot.GetContents(), Is.EqualTo(items));
+        [Test]
+        public void AddItems_EmptySlot_ReturnsEmptyRemainingItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+
+            var addingAmount = this.random.Next(1, stackSize);
+            var addingItems = this.itemFactory.CreateManyRandom(addingAmount);
+
+            var remainingItems = slot.Add(addingItems);
+
+            Assert.That(remainingItems, Is.Empty);
+        }
+
+        [Test]
+        public void AddItems_FullSlot_ThrowsInvalidOperationException()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var items = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.Full(items);
+
+            var addingItems = this.itemFactory.CreateMany(1);
+
+            Assert.That(() => slot.Add(addingItems), Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void AddItems_DifferentItemsFromSlot_ThrowsInvalidOperationException()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var items = new T[1] { this.itemFactory.CreateRandom() };
+            var slot = this.slotFactory.WithItems(items, stackSize);
+
+            var addingItems = this.itemFactory.CreateManyRandom(1);
+
+            Assert.That(() => slot.Add(addingItems), Throws.InvalidOperationException);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Centralize error message strings used by `InventoryStackSlot<T>` to avoid duplicated literals and enable consistent wording. 
- Clarify and tighten exception semantics when adding items so operations that exceed capacity or conflict with slot contents throw `InvalidOperationException` instead of `ArgumentException`.

### Description

- Added `InventoryStackSlotErrors` internal class to house constant error message strings. 
- Replaced inline exception message strings in `InventoryStackSlot<T>.Add(T)` and `Add(T[])` with the new constants and adjusted the order/type of thrown exceptions (notably converting some capacity/different-item cases to throw `InvalidOperationException`).
- Updated `using` directives and minor code reordering in `InventoryStackSlot.cs` to reference the new errors class.
- Updated and extended unit tests under `tests/Slots/...` to reflect the new exception types and return behaviors, including new tests `Add_EmptySlot_ReturnsTrue` and `AddItems_EmptySlot_ReturnsEmptyRemainingItems`.

### Testing

- Ran the unit test suite with `dotnet test` for the modified tests under `tests/Slots/...`. 
- All modified and existing unit tests related to `InventoryStackSlot` and `IInventoryStackSlot` executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f8947de88323bcb800c14c25aaf9)