### PR TITLE
Validate null item arrays and standardize add failure behavior; update tests to expect exceptions

### DIFF
--- a/src/Containers/StackInventory.cs
+++ b/src/Containers/StackInventory.cs
@@ -270,6 +270,8 @@ namespace TheChest.Inventories.Containers
         /// <exception cref="InvalidOperationException">When the items cannot be added to the slot on <paramref name="index"/></exception>
         public virtual T[] AddAt(T[] items, int index)
         {
+            if (items is null)
+                throw new ArgumentNullException(nameof(items));
             if (items.Length == 0)
                 throw new ArgumentException(StackInventoryErrors.CannotAddEmptyArray, nameof(items));
             if (index < 0 || index > this.Size)

--- a/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
+++ b/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItem.cs
@@ -14,27 +14,23 @@
         }
 
         [Test]
-        public void AddItem_FullInventory_DoesNotAddToSlot()
+        public void AddItem_FullInventory_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, this.itemFactory.CreateRandom());
 
-            inventory.Add(item);
-
-            Assert.That(inventory.GetCount(item), Is.Zero);
+            Assert.That(() => inventory.Add(item), Throws.InvalidOperationException);
         }
 
         [Test]
-        public void AddItem_FullInventory_ReturnsFalse()
+        public void AddItem_FullInventory_ThrowsInvalidOperationException_SecondCase()
         {
             var item = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(10, 10, this.itemFactory.CreateRandom());
 
-            var result = inventory.Add(item);
-
-            Assert.That(result, Is.False);
+            Assert.That(() => inventory.Add(item), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
+++ b/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemAt.cs
@@ -17,7 +17,7 @@
         }
 
         [Test]
-        public void AddItemAt_SlotWithDifferentItem_ReturnsFalse()
+        public void AddItemAt_SlotWithDifferentItem_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -26,9 +26,7 @@
 
             var index = this.random.Next(0, size);
             var item = this.itemFactory.CreateDefault();
-            var result = inventory.AddAt(item, index);
-
-            Assert.That(result, Is.False);
+            Assert.That(() => inventory.AddAt(item, index), Throws.InvalidOperationException);
         }
 
         [Test]
@@ -49,7 +47,7 @@
         }
 
         [Test]
-        public void AddItemAt_FullSlotWithSameItem_ReturnsFalse()
+        public void AddItemAt_FullSlotWithSameItem_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -59,9 +57,7 @@
 
             var item = this.itemFactory.CreateDefault();
             var index = this.random.Next(0, size - 1);
-            var result = inventory.AddAt(item, index);
-
-            Assert.That(result, Is.False);
+            Assert.That(() => inventory.AddAt(item, index), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItems.cs
+++ b/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItems.cs
@@ -14,15 +14,13 @@
         }
 
         [Test]
-        public void AddItems_FullInventory_ReturnsNotAddedItems()
+        public void AddItems_FullInventory_ThrowsInvalidOperationException()
         {
             var slotItem = this.itemFactory.CreateRandom();
             var items = this.itemFactory.CreateMany(20);
             var inventory = this.inventoryFactory.FullContainer(20, 2, slotItem);
 
-            var result = inventory.Add(items);
-
-            Assert.That(result, Is.EqualTo(items));
+            Assert.That(() => inventory.Add(items), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
+++ b/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.AddItemsAt.cs
@@ -17,7 +17,7 @@
         }
 
         [Test]
-        public void AddItemsAt_SlotWithDifferentItem_ReturnsItemsFromParams()
+        public void AddItemsAt_SlotWithDifferentItem_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -27,13 +27,11 @@
             var amount = stackSize;
             var items = this.itemFactory.CreateMany(amount);
             var index = this.random.Next(0, size); 
-            var result = inventory.AddAt(items, index);
-
-            Assert.That(result, Is.EqualTo(items));
+            Assert.That(() => inventory.AddAt(items, index), Throws.InvalidOperationException);
         }
 
         [Test]
-        public void AddItemsAt_FullSlotSlotWithSameItem_ReturnsNotAddedItemsFromParam()
+        public void AddItemsAt_FullSlotSlotWithSameItem_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
@@ -42,13 +40,11 @@
 
             var index = this.random.Next(0, size);
             var items = this.itemFactory.CreateMany(stackSize);
-            var result = inventory.AddAt(items, index);
-
-            Assert.That(result, Is.EqualTo(items));
+            Assert.That(() => inventory.AddAt(items, index), Throws.InvalidOperationException);
         }
 
         [Test]
-        public void AddItemsAt_FullSlotWithSameItem_ReturnsNotAddedItems()
+        public void AddItemsAt_FullSlotWithSameItem_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -57,9 +53,7 @@
 
             var items = this.itemFactory.CreateMany(10);
             var index = this.random.Next(0, size);
-            var result = inventory.AddAt(items, index);
-
-            Assert.That(result, Is.Not.Empty.And.EqualTo(items));
+            Assert.That(() => inventory.AddAt(items, index), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
+++ b/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemAt.cs
@@ -56,7 +56,6 @@ namespace TheChest.Inventories.Tests.Containers.Interfaces
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
-            inventory.AddAt(item, randomIndex);
 
             var canAdd = inventory.CanAddAt(item, randomIndex);
 

--- a/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
+++ b/tests/Containers/Interfaces/IStackInventory/IStackInventoryTests.CanAddItemsAt.cs
@@ -77,7 +77,6 @@
             var inventory = this.inventoryFactory.FullContainer(size, stackSize, item);
 
             var randomIndex = this.random.Next(0, size);
-            inventory.AddAt(item, randomIndex);
 
             var items = this.itemFactory.CreateMany(stackSize);
             var canAdd = inventory.CanAddAt(items, randomIndex);

--- a/tests/Containers/StackInventory/StackInventoryTests.AddItem.cs
+++ b/tests/Containers/StackInventory/StackInventoryTests.AddItem.cs
@@ -23,6 +23,14 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueType]
+        public void AddItem_NullItem_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+            Assert.That(() => inventory.Add(default(T)!), Throws.ArgumentNullException);
+        }
+
+        [Test]
         public void AddItem_EmptyInventory_CallsOnAddEvent()
         {
             var item = this.itemFactory.CreateDefault();
@@ -152,7 +160,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
-        public void AddItem_FullInventory_DoesNotCallOnAddEvent()
+        public void AddItem_FullInventory_ThrowsAndDoesNotCallOnAddEvent()
         {
             var item = this.itemFactory.CreateDefault();
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -160,7 +168,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
 
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
 
-            inventory.Add(item);
+            Assert.That(() => inventory.Add(item), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Containers/StackInventory/StackInventoryTests.AddItemAt.cs
+++ b/tests/Containers/StackInventory/StackInventoryTests.AddItemAt.cs
@@ -90,7 +90,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
-        public void AddItemAt_SlotWithDifferentItem_DoesNotCallOnAddEvent()
+        public void AddItemAt_SlotWithDifferentItem_ThrowsAndDoesNotCallOnAddEvent()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -101,7 +101,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
             var item = this.itemFactory.CreateDefault();
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
 
-            inventory.AddAt(item, index);
+            Assert.That(() => inventory.AddAt(item, index), Throws.InvalidOperationException);
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
-        public void AddItemAt_FullSlotWithSameItem_DoesNotAddsToStack()
+        public void AddItemAt_FullSlotWithSameItem_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -162,13 +162,11 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
 
             var index = this.random.Next(0, size);
             var item = this.itemFactory.CreateDefault();
-            inventory.AddAt(item, index);
-
-            Assert.That(inventory.GetItems(index), Has.No.AnyOf(item));
+            Assert.That(() => inventory.AddAt(item, index), Throws.InvalidOperationException);
         }
 
         [Test]
-        public void AddItemAt_FullSlotWithSameItem_DoNotCallsOnAddEvent()
+        public void AddItemAt_FullSlotWithSameItem_ThrowsAndDoNotCallsOnAddEvent()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -180,7 +178,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
 
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
 
-            inventory.AddAt(item, index);
+            Assert.That(() => inventory.AddAt(item, index), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Containers/StackInventory/StackInventoryTests.AddItems.cs
+++ b/tests/Containers/StackInventory/StackInventoryTests.AddItems.cs
@@ -14,9 +14,26 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
             var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
 
             var items = Array.Empty<T>();
-            var result = inventory.Add(items);
+            Assert.That(() => inventory.Add(items), Throws.ArgumentException);
+        }
 
-            Assert.That(result, Is.Empty);
+        [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueType]
+        public void AddItems_NullItems_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+            Assert.That(() => inventory.Add(null!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueType]
+        public void AddItems_ItemsContainsNull_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer(5, 5);
+            var validItem = this.itemFactory.CreateDefault();
+            var items = new T[] { validItem, default!, validItem };
+
+            Assert.That(() => inventory.Add(items), Throws.ArgumentNullException);
         }
 
         [Test]
@@ -212,21 +229,17 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
-        public void AddItems_FullInventory_DoNotAddsItems()
+        public void AddItems_FullInventory_ThrowsInvalidOperationException()
         {
             var slotItem = this.itemFactory.CreateRandom();
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var items = this.itemFactory.CreateMany(size);
-            var expectedItems = items.ToArray();
             var inventory = this.inventoryFactory.FullContainer(size, 2, slotItem);
-
-            inventory.Add(items);
-
-            Assert.That(items, Is.EqualTo(expectedItems));
+            Assert.That(() => inventory.Add(items), Throws.InvalidOperationException);
         }
 
         [Test]
-        public void AddItems_FullInventory_DoNotCallOnAddEvent()
+        public void AddItems_FullInventory_ThrowsAndDoNotCallOnAddEvent()
         {
             var slotItem = this.itemFactory.CreateRandom();
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -235,7 +248,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
 
             inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd event should not be called when item is not possible to add");
 
-            inventory.Add(items);
+            Assert.That(() => inventory.Add(items), Throws.InvalidOperationException);
         }
     }
 }

--- a/tests/Containers/StackInventory/StackInventoryTests.AddItemsAt.cs
+++ b/tests/Containers/StackInventory/StackInventoryTests.AddItemsAt.cs
@@ -18,6 +18,38 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueType]
+        public void AddItemsAt_NullItems_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer(5, 5);
+            Assert.That(() => inventory.AddAt(null!, 0), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        [TheChest.Tests.Common.Attributes.IgnoreIfValueType]
+        public void AddItemsAt_ItemsContainsNull_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer(5, 5);
+            var validItem = this.itemFactory.CreateDefault();
+            var items = new T[] { validItem, default!, validItem };
+
+            Assert.That(() => inventory.AddAt(items, 0), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void AddItemsAt_ItemsAreNotAllEqual_ThrowsArgumentException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer(5, 5);
+            var first = this.itemFactory.CreateDefault();
+            var second = this.itemFactory.CreateRandom();
+            while (Equals(first, second))
+                second = this.itemFactory.CreateRandom();
+            var items = new[] { first, second };
+
+            Assert.That(() => inventory.AddAt(items, 0), Throws.ArgumentException);
+        }
+
+        [Test]
         public void AddItemsAt_SlotWithSameItem_AddsToStack()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
@@ -42,7 +74,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
-        public void AddItemsAt_FullSlotWithSameItem_DoNotAddsToStack()
+        public void AddItemsAt_FullSlotWithSameItem_ThrowsInvalidOperationException()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var slotItem = this.itemFactory.CreateDefault();
@@ -51,13 +83,11 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
 
             var index = this.random.Next(0, size);
             var items = this.itemFactory.CreateMany(10);
-            inventory.AddAt(items, index);
-
-            Assert.That(inventory.GetItems(index), Has.No.AnyOf(items));
+            Assert.That(() => inventory.AddAt(items, index), Throws.InvalidOperationException);
         }
 
         [Test]
-        public void AddItemsAt_FullSlotWithSameItem_DoesNotCallOnAddEvent()
+        public void AddItemsAt_FullSlotWithSameItem_ThrowsAndDoesNotCallOnAddEvent()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -68,7 +98,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
 
             var items = this.itemFactory.CreateMany(10);
             var index = this.random.Next(0, size);
-            inventory.AddAt(items, index);
+            Assert.That(() => inventory.AddAt(items, index), Throws.InvalidOperationException);
         }
 
         [Test]
@@ -113,7 +143,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
         }
 
         [Test]
-        public void AddItemsAt_SlotWithDifferentItem_DoesNotCallOnAddEvent()
+        public void AddItemsAt_SlotWithDifferentItem_ThrowsAndDoesNotCallOnAddEvent()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -124,7 +154,7 @@ namespace TheChest.Inventories.Tests.Containers.StackInventory
 
             var items = this.itemFactory.CreateMany(stackSize);
             var index = this.random.Next(0, size - 1);
-            inventory.AddAt(items, index);
+            Assert.That(() => inventory.AddAt(items, index), Throws.InvalidOperationException);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure add APIs properly validate null array inputs and do not silently accept invalid parameters. 
- Standardize behavior when items cannot be added so failures surface as exceptions instead of silent false/partial returns. 
- Reflect the stricter semantics in the unit tests and ensure events are not raised for failing operations.

### Description
- Added a null check in `StackInventory.AddAt(T[] items, int index)` to throw `ArgumentNullException` when `items` is `null`.
- Updated tests in `tests/Containers/Interfaces/IStackInventory/*` and `tests/Containers/StackInventory/*` to expect `InvalidOperationException` for add attempts that are not possible and to expect `ArgumentNullException`/`ArgumentException` for invalid input arrays. 
- Added tests for null/containing-null item arrays and null single-item cases such as `AddItem_NullItem_ThrowsArgumentNullException`, `AddItems_NullItems_ThrowsArgumentNullException`, and `AddItems_ItemsContainsNull_ThrowsArgumentNullException` (guarded by `IgnoreIfValueType` where appropriate). 
- Adjusted several tests to assert that `OnAdd` is not invoked when an add operation fails by throwing.

### Testing
- Ran the inventory/container unit tests under `tests/Containers/Interfaces` and `tests/Containers/StackInventory` using the project NUnit runner. 
- All modified tests passed after updating expectations to the new exception-based behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6320b26808323a27273eecc52f174)