### PR TITLE
Add reusable test-generation agent skill and Copilot guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Copilot Instructions
+
+When generating or updating tests for this repository, follow the rules in `skills/test-generator/SKILL.md`.
+
+Key reminders:
+- Use factory classes and inherit `BaseTests<T>`.
+- Keep test methods ordered by production execution flow.
+- Use partial test classes split by method/overload.
+- Follow naming pattern `[Method]_[Context]_[ExpectedResult]`.
+- Use `TestFixture` for `TestItem`, `TestEnumItem`, and `TestStructItem`.
+- Keep common classes in `TheChest.Tests.Common` and test-only extensions as `internal` in `TheChest.Tests.Common.Extensions`.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ More usage and extension details are available in the `docs/` folder.
 ## Future plans
 
 Future version plans are available on the [GitHub Project Board](https://github.com/orgs/The-Chest/projects/19/views/2).
+
+## Agent skill for test creation
+
+This repository includes an agent skill for standardized test generation:
+
+- `skills/test-generator/SKILL.md`
+
+Use this skill to keep test naming, structure, fixture coverage, and common namespaces consistent.

--- a/skills/test-generator/SKILL.md
+++ b/skills/test-generator/SKILL.md
@@ -1,0 +1,59 @@
+# Test Creation Skill
+
+Use this skill whenever creating or updating tests in this repository.
+
+## Test rules
+
+### Tests
+- Tests should ALWAYS:
+  - Use factory classes.
+  - Inherit `BaseTests<T>` and inject its factories.
+  - Follow the order of execution of the code.
+    - Example method:
+    ```csharp
+    public virtual bool AddAt(T item, int index)
+    {
+      if (item.IsNull())
+       throw new ArgumentNullException(nameof(item));
+      if (index > this.Size || index < 0)
+        throw new ArgumentOutOfRangeException(nameof(index));
+      if (!this.slots[index].CanAdd(item))
+        throw new InvalidOperationException(StackInventoryErrors.NotPossibleToAddItem);
+
+      this.slots[index].Add(item);
+      this.OnAdd?.Invoke(this, (new[] { item }, index));
+
+      return added;
+    }
+    ```
+    - Unit tests should be organized in the following order:
+      1. `AddAt_NullItem_ThrowsArgumentNullException`
+      2. `AddAt_InvalidIndex_ThrowsArgumentOutOfRangeException`
+      3. `AddAt_SlotCannotAdd_ThrowsInvalidOperationException`
+      4. `AddAt_SlotCanAdd_AddsToSlotAtIndex`
+      5. `AddAt_SlotCanAdd_CallsOnAddEvent`
+      6. `AddAt_SlotCanAdd_ReturnsNotAddedItems`
+  - Use `[TestFixture(typeof([T]))]` for the following types:
+    - `TestItem`
+    - `TestEnumItem`
+    - `TestStructItem`
+
+### Class organization
+- Test classes are organized by methods in partial classes.
+  - Example:
+    - `Container<T>.Add` -> `ContainerTests.Add.cs`
+    - `Container<T>.Get` -> `ContainerTests.Get.cs`
+- If the method has an overload, separate each overload in different partial class files.
+  - Example:
+    - `Container<T>.Get(int index)` -> `ContainerTests.GetByIndex.cs`
+    - `Container<T>.Get(T item)` -> `ContainerTests.GetItem.cs`
+
+### Naming
+- Tests should follow: `[Method]_[Context]_[ExpectedResult]`.
+  - Example for `Move(int origin, int target)`:
+    - Invalid origin test: `Move_NegativeOrigin_ThrowsArgumentOutOfRangeException`
+    - Valid test case: `Move_ValidOriginAndTarget_SwapsItemsFromSlots`
+
+### Common namespace and extensions
+- Common classes must always be inside namespace `TheChest.Tests.Common`.
+- Extension methods used only by tests should be `internal` and in namespace `TheChest.Tests.Common.Extensions`.

--- a/skills/test-generator/SKILL.md
+++ b/skills/test-generator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: test-creation-skill
+description: Repository-specific guidance for generating and organizing unit tests using BaseTests<T>, factories, fixture types, naming conventions, and partial-class file structure.
+---
+
 # Test Creation Skill
 
 Use this skill whenever creating or updating tests in this repository.


### PR DESCRIPTION
### Motivation
- Provide a standard, reusable skill that encodes repository-specific test rules (factories, `BaseTests<T>`, test ordering, naming, partial class organization, and fixture coverage) to ensure consistent test generation. 
- Ensure GitHub Copilot and other agents follow the same rules when generating or updating tests by adding repository guidance.

### Description
- Add `skills/test-generator/SKILL.md` containing the test-authoring rules and examples for this repository. 
- Add `.github/copilot-instructions.md` to instruct Copilot to use the new skill when creating or updating tests. 
- Update `README.md` to document the presence and purpose of the test-generation skill.

### Testing
- No automated unit or integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6abfe5f1483239233463eb4fa9f20)