### PR TITLE
Add test-creation agent skill and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Test Creation Skill
 - When creating or updating tests, follow `skills/test-generator/SKILL.md`.
-- Use factory classes and inherit from `BaseTests<T>`.
+- Use factory classes and inherit from `BaseTest<T>`.
 - Keep test names in `[Method]_[Context]_[ExpectedResult]` format.
 - Organize tests in partial classes split by method and overload.
 - Use fixtures for `TestItem`, `TestEnumItem`, and `TestStructItem`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS Instructions
+
+## Test Creation Skill
+- When creating or updating tests, follow `skills/test-generator/SKILL.md`.
+- Use factory classes and inherit from `BaseTests<T>`.
+- Keep test names in `[Method]_[Context]_[ExpectedResult]` format.
+- Organize tests in partial classes split by method and overload.
+- Use fixtures for `TestItem`, `TestEnumItem`, and `TestStructItem`.
+
+## Common Test Namespaces
+- Keep common test classes in `TheChest.Tests.Common`.
+- Keep test-only extension methods `internal` in `TheChest.Tests.Common.Extensions`.

--- a/README.md
+++ b/README.md
@@ -95,11 +95,3 @@ More usage and extension details are available in the `docs/` folder.
 ## Future plans
 
 Future version plans are available on the [GitHub Project Board](https://github.com/orgs/The-Chest/projects/19/views/2).
-
-## Agent skill for test creation
-
-This repository includes an agent skill for standardized test generation:
-
-- `skills/test-generator/SKILL.md`
-
-Use this skill to keep test naming, structure, fixture coverage, and common namespaces consistent.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ More usage and extension details are available in the `docs/` folder.
 ## Future plans
 
 Future version plans are available on the [GitHub Project Board](https://github.com/orgs/The-Chest/projects/19/views/2).
+
+## Agent skill for test creation
+
+This repository includes an agent skill for standardized test generation:
+
+- `skills/test-generator/SKILL.md`
+
+Use this skill to keep test naming, structure, fixture coverage, and common namespaces consistent.

--- a/skills/test-generator/SKILL.md
+++ b/skills/test-generator/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: test-creation-skill
+description: Repository-specific guidance for generating and organizing unit tests using BaseTests<T>, factories, fixture types, naming conventions, and partial-class file structure.
+---
+
+# Test Creation Skill
+
+Use this skill whenever creating or updating tests in this repository.
+
+## Test rules
+
+### Tests
+- Tests should ALWAYS:
+  - Use factory classes.
+  - Inherit `BaseTests<T>` and inject its factories.
+  - Follow the order of execution of the code.
+    - Example method:
+    ```csharp
+    public virtual bool AddAt(T item, int index)
+    {
+      if (item.IsNull())
+       throw new ArgumentNullException(nameof(item));
+      if (index > this.Size || index < 0)
+        throw new ArgumentOutOfRangeException(nameof(index));
+      if (!this.slots[index].CanAdd(item))
+        throw new InvalidOperationException(StackInventoryErrors.NotPossibleToAddItem);
+
+      this.slots[index].Add(item);
+      this.OnAdd?.Invoke(this, (new[] { item }, index));
+
+      return added;
+    }
+    ```
+    - Unit tests should be organized in the following order:
+      1. `AddAt_NullItem_ThrowsArgumentNullException`
+      2. `AddAt_InvalidIndex_ThrowsArgumentOutOfRangeException`
+      3. `AddAt_SlotCannotAdd_ThrowsInvalidOperationException`
+      4. `AddAt_SlotCanAdd_AddsToSlotAtIndex`
+      5. `AddAt_SlotCanAdd_CallsOnAddEvent`
+      6. `AddAt_SlotCanAdd_ReturnsNotAddedItems`
+  - Use `[TestFixture(typeof([T]))]` for the following types:
+    - `TestItem`
+    - `TestEnumItem`
+    - `TestStructItem`
+
+### Class organization
+- Test classes are organized by methods in partial classes.
+  - Example:
+    - `Container<T>.Add` -> `ContainerTests.Add.cs`
+    - `Container<T>.Get` -> `ContainerTests.Get.cs`
+- If the method has an overload, separate each overload in different partial class files.
+  - Example:
+    - `Container<T>.Get(int index)` -> `ContainerTests.GetByIndex.cs`
+    - `Container<T>.Get(T item)` -> `ContainerTests.GetItem.cs`
+
+### Naming
+- Tests should follow: `[Method]_[Context]_[ExpectedResult]`.
+  - Example for `Move(int origin, int target)`:
+    - Invalid origin test: `Move_NegativeOrigin_ThrowsArgumentOutOfRangeException`
+    - Valid test case: `Move_ValidOriginAndTarget_SwapsItemsFromSlots`
+
+### Common namespace and extensions
+- Common classes must always be inside namespace `TheChest.Tests.Common`.
+- Extension methods used only by tests should be `internal` and in namespace `TheChest.Tests.Common.Extensions`.


### PR DESCRIPTION
### Motivation
- Provide repository-specific guidance for generating unit tests to ensure consistent naming, fixtures, factory usage, and partial-class organization when creating or updating tests.
- Make the test-generation skill discoverable in the project documentation so contributors and automated agents follow the same conventions.

### Description
- Add `skills/test-generator/SKILL.md` which defines the `test-creation-skill` and details rules for using factory classes, inheriting `BaseTests<T>`, fixtures, naming conventions, and partial-class file organization.
- Add `AGENTS.md` to summarize the test-creation guidance and common test namespaces and extension visibility rules.
- Update `README.md` to reference the new agent skill and point readers to `skills/test-generator/SKILL.md` for standardized test generation guidance.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6abfe5f1483239233463eb4fa9f20)