### PR TITLE
Add Inventory replace unit tests

### DIFF
--- a/tests/Containers/Interfaces/IInventory/IInventoryTests.CanReplace.cs
+++ b/tests/Containers/Interfaces/IInventory/IInventoryTests.CanReplace.cs
@@ -2,5 +2,28 @@
 {
     public partial class IInventoryTests<T>
     {
+        [Test]
+        public void CanReplace_EmptySlot_ReturnsTrue()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var randomIndex = this.random.Next(0, size);
+
+            var result = inventory.CanReplace(this.itemFactory.CreateDefault(), randomIndex);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void CanReplace_FullSlot_ReturnsTrue()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.FullContainer(size, this.itemFactory.CreateDefault());
+            var randomIndex = this.random.Next(0, size);
+
+            var result = inventory.CanReplace(this.itemFactory.CreateRandom(), randomIndex);
+
+            Assert.That(result, Is.True);
+        }
     }
 }

--- a/tests/Containers/Inventory/InventoryTests.CanReplace.cs
+++ b/tests/Containers/Inventory/InventoryTests.CanReplace.cs
@@ -1,6 +1,68 @@
-﻿namespace TheChest.Inventories.Tests.Containers.Inventory
+﻿using TheChest.Tests.Common.Attributes;
+
+namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
+        [Test]
+        [IgnoreIfValueType]
+        public void CanReplace_NullItem_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            Assert.That(
+                () => inventory.CanReplace(default!, 0),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [TestCase(-1)]
+        [TestCase(MAX_SIZE_TEST + 1)]
+        public void CanReplace_InvalidSlotIndex_ThrowsArgumentOutOfRangeException(int index)
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            Assert.That(
+                () => inventory.CanReplace(this.itemFactory.CreateDefault(), index),
+                Throws.Exception.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void CanReplace_IndexEqualToSize_ThrowsArgumentOutOfRangeException()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            Assert.That(
+                () => inventory.CanReplace(this.itemFactory.CreateDefault(), size),
+                Throws.Exception.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void CanReplace_EmptySelectedSlot_ReturnsTrue()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var randomIndex = this.random.Next(0, size);
+
+            var canReplace = inventory.CanReplace(this.itemFactory.CreateDefault(), randomIndex);
+
+            Assert.That(canReplace, Is.True);
+        }
+
+        [Test]
+        public void CanReplace_FullSelectedSlot_ReturnsTrue()
+        {
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.FullContainer(size, this.itemFactory.CreateDefault());
+            var randomIndex = this.random.Next(0, size);
+
+            var canReplace = inventory.CanReplace(this.itemFactory.CreateRandom(), randomIndex);
+
+            Assert.That(canReplace, Is.True);
+        }
     }
 }

--- a/tests/Containers/Inventory/InventoryTests.Replace.cs
+++ b/tests/Containers/Inventory/InventoryTests.Replace.cs
@@ -1,10 +1,22 @@
-﻿using TheChest.Tests.Common.Extensions.Containers;
+﻿using TheChest.Tests.Common.Attributes;
+using TheChest.Tests.Common.Extensions.Containers;
 
-using TheChest.Tests.Common.Attributes;
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
+        [Test]
+        [IgnoreIfValueType]
+        public void Replace_NullItem_ThrowsArgumentNullException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer();
+
+            Assert.That(
+                () => inventory.Replace(default!, 0),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
         [TestCase(-1)]
         [TestCase(MAX_SIZE_TEST + 1)]
         public void Replace_InvalidSlotIndex_ThrowsArgumentOutOfRangeException(int index)
@@ -14,16 +26,20 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
 
             Assert.That(
                 () => inventory.Replace(this.itemFactory.CreateDefault(), index),
-                Throws.Exception.TypeOf<ArgumentOutOfRangeException>()
+                Throws.Exception.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
             );
         }
 
         [Test]
-        [IgnoreIfValueType]
-        public void Replace_NullItem_ThrowsArgumentNullException()
+        public void Replace_IndexEqualToSize_ThrowsArgumentOutOfRangeException()
         {
-            var inventory = this.inventoryFactory.EmptyContainer();
-            Assert.That(() => inventory.Replace(default!, 0), Throws.ArgumentNullException);
+            var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            Assert.That(
+                () => inventory.Replace(this.itemFactory.CreateDefault(), size),
+                Throws.Exception.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
         }
 
         [Test]
@@ -31,29 +47,29 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(size);
-
             var randomIndex = this.random.Next(0, size);
             var item = this.itemFactory.CreateDefault();
+
             inventory.Replace(item, randomIndex);
 
             Assert.That(inventory.GetItem<T>(randomIndex), Is.EqualTo(item));
         }
 
         [Test]
-        public void Replace_EmptySlot_CallsOnAddEventWithEmptyOldItem()
+        public void Replace_EmptySlot_CallsOnReplaceEventWithEmptyOldItem()
         {
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var inventory = this.inventoryFactory.EmptyContainer(size);
-
             var randomIndex = this.random.Next(0, size);
             var item = this.itemFactory.CreateDefault();
-
             var raised = false;
+
             inventory.OnReplace += (sender, args) =>
             {
                 Assert.Multiple(() =>
                 {
                     Assert.That(sender, Is.EqualTo(inventory));
+                    Assert.That(args.Data.Select(x => x.Index), Has.All.EqualTo(randomIndex));
                     Assert.That(args.Data.Select(x => x.OldItem), Has.All.Null);
                     Assert.That(args.Data.Select(x => x.NewItem), Has.All.EqualTo(item));
                 });
@@ -71,9 +87,9 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var initialItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, initialItem);
-
             var randomIndex = this.random.Next(0, size);
             var newItem = this.itemFactory.CreateRandom();
+
             inventory.Replace(newItem, randomIndex);
 
             Assert.That(inventory.GetItem(randomIndex), Is.EqualTo(newItem));
@@ -85,21 +101,22 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
             var size = this.random.Next(MIN_SIZE_TEST, MAX_SIZE_TEST);
             var initialItem = this.itemFactory.CreateDefault();
             var inventory = this.inventoryFactory.FullContainer(size, initialItem);
-
             var randomIndex = this.random.Next(0, size);
             var newItem = this.itemFactory.CreateRandom();
-
             var raised = false;
+
             inventory.OnReplace += (sender, args) =>
             {
                 Assert.Multiple(() =>
                 {
                     Assert.That(sender, Is.EqualTo(inventory));
+                    Assert.That(args.Data.Select(x => x.Index), Has.All.EqualTo(randomIndex));
                     Assert.That(args.Data.Select(x => x.OldItem), Has.All.EqualTo(initialItem));
                     Assert.That(args.Data.Select(x => x.NewItem), Has.All.EqualTo(newItem));
                 });
                 raised = true;
             };
+
             inventory.Replace(newItem, randomIndex);
 
             Assert.That(raised, Is.True, "OnReplace event was not raised");


### PR DESCRIPTION
### Motivation
- Improve coverage for `Inventory<T>.CanReplace` and `Inventory<T>.Replace` to assert argument validation, boundary conditions, and event payload correctness.
- Ensure the `IInventory<T>` contract has explicit tests for `CanReplace` behavior on empty and full slots.

### Description
- Added/updated tests in `tests/Containers/Inventory/InventoryTests.CanReplace.cs` to validate null-item behavior, invalid index and index-equals-size exceptions, and successful results for empty and full slots, using `[IgnoreIfValueType]` where appropriate.
- Expanded `tests/Containers/Inventory/InventoryTests.Replace.cs` to assert parameter-name on exceptions, cover index-equals-size, verify replacement into empty/full slots, and assert that `OnReplace` event payload includes the replaced slot index.
- Added interface-level contract tests in `tests/Containers/Interfaces/IInventory/IInventoryTests.CanReplace.cs` to verify `CanReplace` returns true for both empty and full slots.

### Testing
- Ran `dotnet test --no-restore` against the test suite; all tests passed with no failures (Passed: 626, Skipped: 10, Total: 636).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03bfcf28888323b47c1b9262cad09a)