### PR TITLE
Add TryAdd and TryAddAt non-throwing APIs to StackInventory and accompanying tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   * `Inventory`
     * `TryAdd(T[] items)` - Tries to add all the items in the array to the inventory, returns the items that couldn't be added
     * `TryAddAt(T item, int index)` - Tries to add an item to a specific index, returns the item if it couldn't be added
+  * `StackInventory`
+    * `TryAdd(params T[] items)` - Tries to add all items to the inventory and returns `true` when all items are added; otherwise `false`
+    * `TryAddAt(T item, int index)` - Tries to add an item to a specific stack slot and returns `true` on success; otherwise `false`
 
 ## What's Changed
 * 

--- a/docs/stack_inventory/class_diagram.md
+++ b/docs/stack_inventory/class_diagram.md
@@ -37,7 +37,9 @@ direction TB
 	        + bool CanAddAt(T[] items, int index)
 
             + bool Add(T item)
+            + bool TryAdd(params T[] items)
             + bool AddAt(T item, int index)
+            + bool TryAddAt(T item, int index)
             + T[] Add(params T[] items)
             + T[] AddAt(T[] items, int index)
 
@@ -90,7 +92,9 @@ direction TB
 	        + bool CanAddAt(T[] items, int index)
 
             + bool Add(T item)
+            + bool TryAdd(params T[] items)
             + bool AddAt(T item, int index)
+            + bool TryAddAt(T item, int index)
             + T[] Add(params T[] items)
             + T[] AddAt(T[] items, int index)
 

--- a/docs/stack_inventory/class_diagram.md
+++ b/docs/stack_inventory/class_diagram.md
@@ -41,6 +41,7 @@ direction TB
             + bool AddAt(T item, int index)
             + bool TryAddAt(T item, int index)
             + T[] Add(params T[] items)
+            + T[] AddItems(params T[] items)
             + T[] AddAt(T[] items, int index)
 
             + T[] Clear()

--- a/src/Containers/Interfaces/IStackInventory.cs
+++ b/src/Containers/Interfaces/IStackInventory.cs
@@ -78,6 +78,12 @@ namespace TheChest.Inventories.Containers.Interfaces
         bool CanAdd(params T[] items);
 
         /// <summary>
+        /// Attempts to add the specified items to the Inventory.
+        /// </summary>
+        /// <param name="items">An array of items to add.</param>
+        /// <returns><see langword="true"/> if all items were added successfully; otherwise, <see langword="false"/>.</returns>
+        bool TryAdd(params T[] items);
+        /// <summary>
         /// Adds and array of item in a avaliable slot
         /// </summary>
         /// <param name="items">Array of items to be added to any avaliable slot found</param>
@@ -144,6 +150,13 @@ namespace TheChest.Inventories.Containers.Interfaces
         /// <param name="index">slot where the item will be added</param>
         /// <returns><see langword="true"/> if the <paramref name="item"/> could be added to the <paramref name="index"/></returns>
         bool AddAt(T item, int index);
+        /// <summary>
+        /// Attempts to add the specified item at the given index in the inventory.
+        /// </summary>
+        /// <param name="item">The item to add to the inventory.</param>
+        /// <param name="index">The zero-based index at which to insert the item.</param>
+        /// <returns><see langword="true"/> if the <paramref name="item"/> was successfully added at the specified <paramref name="index"/>; otherwise, <see langword="false"/>.</returns>
+        bool TryAddAt(T item, int index);
         /// <summary>
         /// Adds an array of items inside the inventory
         /// </summary>

--- a/src/Containers/StackInventory.Add.cs
+++ b/src/Containers/StackInventory.Add.cs
@@ -152,6 +152,24 @@ namespace TheChest.Inventories.Containers
             return items;
         }
         /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException">When <paramref name="items"/> is <see langword="null"/> or has one item <see langword="null"/></exception>
+        public virtual bool TryAdd(params T[] items)
+        {
+            if (items is null)
+                throw new ArgumentNullException(nameof(items));
+            if (items.Length == 0)
+                return true;
+            if (items.ContainsNull())
+                throw new ArgumentNullException(nameof(items), StackInventoryErrors.ItemArrayContainsNull);
+            if (!items.HasAllEqual())
+                throw new ArgumentException(StackInventoryErrors.CannotAddArrayWithDifferentItems, nameof(items));
+
+            if (!this.CanAddItems(items))
+                return false;
+
+            return this.AddItems(items).Length == 0;
+        }
+        /// <inheritdoc/>
         /// <remarks>
         /// The method fires <see cref="OnAdd"/> event when <paramref name="item"/> is added to the inventory. 
         /// </remarks>
@@ -211,6 +229,25 @@ namespace TheChest.Inventories.Containers
                 this.OnAdd?.Invoke(this, (new[] { item }, index));
 
             return added;
+        }
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">When <paramref name="index"/> is smaller than zero or bigger than <see cref="Container{T}.Size"/></exception>
+        public virtual bool TryAddAt(T item, int index)
+        {
+            if (item.IsNull())
+                throw new ArgumentNullException(nameof(item));
+            if (index < 0 || index >= this.Size)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            try
+            {
+                return this.AddAt(item, index);
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
         }
         /// <inheritdoc/>
         /// <exception cref="ArgumentOutOfRangeException">When <paramref name="index"/> added is bigger than Slot or smaller than zero</exception>

--- a/tests/Containers/StackInventory/StackInventoryTests.TryAddItemAt.cs
+++ b/tests/Containers/StackInventory/StackInventoryTests.TryAddItemAt.cs
@@ -1,0 +1,87 @@
+﻿using TheChest.Tests.Common.Extensions.Containers;
+
+namespace TheChest.Inventories.Tests.Containers.StackInventory
+{
+    public partial class StackInventoryTests<T>
+    {
+        [Test]
+        public void TryAddItemAt_NullItem_ThrowsArgumentNullException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryAddAt(default!, 0),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [TestCase(-1)]
+        [TestCase(MAX_SIZE_TEST)]
+        public void TryAddItemAt_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+
+            Assert.That(
+                () => inventory.TryAddAt(item, index),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void TryAddItemAt_FullSlot_ReturnsFalse()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var slotItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, slotItem);
+
+            var result = inventory.TryAddAt(slotItem, 0);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAddItemAt_FullSlot_DoesNotCallOnAddEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var slotItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, slotItem);
+
+            inventory.OnAdd += (_, _) => Assert.Fail("OnAdd event should not be called when TryAddAt returns false");
+            inventory.TryAddAt(slotItem, 0);
+        }
+
+        [Test]
+        public void TryAddItemAt_EmptySlot_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+
+            var result = inventory.TryAddAt(item, 0);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryAddItemAt_EmptySlot_CallsOnAddEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+
+            var raised = false;
+            inventory.OnAdd += (_, args) =>
+            {
+                Assert.That(args.Data, Has.Count.EqualTo(1));
+                raised = true;
+            };
+
+            inventory.TryAddAt(item, 0);
+
+            Assert.That(raised, Is.True);
+        }
+    }
+}

--- a/tests/Containers/StackInventory/StackInventoryTests.TryAddItems.cs
+++ b/tests/Containers/StackInventory/StackInventoryTests.TryAddItems.cs
@@ -1,0 +1,117 @@
+﻿using System.Linq;
+using TheChest.Core.Slots.Interfaces;
+using TheChest.Tests.Common.Extensions.Containers;
+using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Containers.StackInventory
+{
+    public partial class StackInventoryTests<T>
+    {
+        [Test]
+        public void TryAddItems_NullItems_ThrowsArgumentNullException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryAdd(null!),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("items")
+            );
+        }
+
+        [Test]
+        public void TryAddItems_EmptyArray_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var result = inventory.TryAdd(Array.Empty<T>());
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryAddItems_ItemsContainsNull_ThrowsArgumentNullException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var validItem = this.itemFactory.CreateDefault();
+            var items = new T[] { validItem, default!, validItem };
+
+            Assert.That(
+                () => inventory.TryAdd(items),
+                Throws.ArgumentNullException
+                    .With.Property("ParamName").EqualTo("items").And
+                    .Message.Contains("One of the items to add is null")
+            );
+        }
+
+        [Test]
+        public void TryAddItems_ItemsAreNotAllEqual_ThrowsArgumentException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var items = new[] { this.itemFactory.CreateDefault(), this.itemFactory.CreateRandom() };
+
+            Assert.That(
+                () => inventory.TryAdd(items),
+                Throws.ArgumentException
+                    .With.Property("ParamName").EqualTo("items").And
+                    .Message.Contains("Cannot add an array of items with different types")
+            );
+        }
+
+        [Test]
+        public void TryAddItems_NotEnoughSpace_ReturnsFalse()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var items = Enumerable.Repeat(item, size * stackSize + 1).ToArray();
+            var result = inventory.TryAdd(items);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAddItems_NotEnoughSpace_DoesNotAddItems()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var items = Enumerable.Repeat(item, size * stackSize + 1).ToArray();
+            inventory.TryAdd(items);
+
+            Assert.That(inventory.GetSlots(), Has.All.Matches<IStackSlot<T>>(x => x.IsEmpty));
+        }
+
+        [Test]
+        public void TryAddItems_NotEnoughSpace_DoesNotCallOnAddEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var items = Enumerable.Repeat(item, size * stackSize + 1).ToArray();
+            inventory.OnAdd += (_, _) => Assert.Fail("OnAdd event should not be called when TryAdd returns false");
+
+            inventory.TryAdd(items);
+        }
+
+        [Test]
+        public void TryAddItems_ItemsFit_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            var items = this.itemFactory.CreateMany(stackSize);
+            var result = inventory.TryAdd(items);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide non-throwing variants to attempt adding items to the inventory or to a specific slot so callers can check success without handling exceptions.

### Description
- Added `bool TryAdd(params T[] items)` to `IStackInventory<T>` and implemented it in `StackInventory.Add.cs` with input validation and a fast path using `CanAddItems` and `AddItems` to determine success.
- Added `bool TryAddAt(T item, int index)` to `IStackInventory<T>` and implemented it to validate parameters and return `false` when `AddAt` would throw `InvalidOperationException`.
- Preserved existing `Add`/`AddAt` behavior and event firing semantics so `OnAdd` is only invoked when items are actually added.
- Added unit tests `StackInventoryTests.TryAddItems.cs` and `StackInventoryTests.TryAddItemAt.cs` to cover null/empty inputs, mixed-item arrays, insufficient space, index validation, success cases, and `OnAdd` event behavior.

### Testing
- Ran the unit test suite including the new tests in `tests/Containers/StackInventory/StackInventoryTests.TryAddItems.cs` and `StackInventoryTests.TryAddItemAt.cs`, and all tests passed.
- Verified `TryAdd` returns `false` and does not raise `OnAdd` when there is not enough space, and returns `true` when items fit.
- Verified `TryAddAt` returns `false` on a full slot and does not raise `OnAdd`, and returns `true` and raises `OnAdd` when the item is successfully added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1439a089a883238681b7277d629cfc)