### PR TITLE
Introduce TryAdd/TryAddAt and consolidate add logic in LazyStackInventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * 
 
 ## What's Fixed
-* Added unit-test coverage for `TryAdd` and `TryAddAt` success/failure and argument-validation behavior
+* 
 
 ## Known Issues
 * **No support for structs or value types** 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Unreleased
+
+## What's Added
+* `LazyStackInventory<T>` try-add APIs
+  * `ILazyStackInventory<T>.TryAdd(T item, int amount)` - Tries to add the requested amount to the inventory and returns `true` only when all requested items are added.
+  * `ILazyStackInventory<T>.TryAddAt(T item, int index, int amount)` - Tries to add the requested amount to a specific slot and returns `true` only when all requested items are added.
+
+## What's Changed
+* `LazyStackInventory<T>` add implementation refactor
+  * Added protected helper `AddItem(T item, int amount)` to centralize inventory-wide add behavior and `OnAdd` event dispatch for successful additions.
+  * Added protected helper `AddItemAt(T item, int index, int amount)` to centralize add-at-index behavior and `OnAdd` event dispatch for successful additions.
+  * `Add(T item, int amount)`, `TryAdd(T item, int amount)`, `AddAt(T item, int index, int amount)`, and `TryAddAt(T item, int index, int amount)` now share the centralized add helpers.
+
+## What's Fixed
+* Added unit-test coverage for `TryAdd` and `TryAddAt` success/failure and argument-validation behavior.
+
+---
+
 # v0.17.0
 
 ## What's Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,3 @@
-# Unreleased
-
-## What's Added
-* `LazyStackInventory<T>` try-add APIs
-  * `ILazyStackInventory<T>.TryAdd(T item, int amount)` - Tries to add the requested amount to the inventory and returns `true` only when all requested items are added.
-  * `ILazyStackInventory<T>.TryAddAt(T item, int index, int amount)` - Tries to add the requested amount to a specific slot and returns `true` only when all requested items are added.
-
-## What's Changed
-* `LazyStackInventory<T>` add implementation refactor
-  * Added protected helper `AddItem(T item, int amount)` to centralize inventory-wide add behavior and `OnAdd` event dispatch for successful additions.
-  * Added protected helper `AddItemAt(T item, int index, int amount)` to centralize add-at-index behavior and `OnAdd` event dispatch for successful additions.
-  * `Add(T item, int amount)`, `TryAdd(T item, int amount)`, `AddAt(T item, int index, int amount)`, and `TryAddAt(T item, int index, int amount)` now share the centralized add helpers.
-
-## What's Fixed
-* Added unit-test coverage for `TryAdd` and `TryAddAt` success/failure and argument-validation behavior.
-
----
-
 # v0.17.0
 
 ## What's Added
@@ -24,14 +6,21 @@
     * `TryAdd(T[] items)` - Tries to add all the items in the array to the inventory, returns the items that couldn't be added
     * `TryAddAt(T item, int index)` - Tries to add an item to a specific index, returns the item if it couldn't be added
 
+  * `LazyStackInventory`
+    * `TryAdd(T item, int amount)` - Tries to add the requested amount to the inventory and returns `true` only when all requested items are added
+    * `TryAddAt(T item, int index, int amount)` - Tries to add the requested amount to a specific slot and returns `true` only when all requested items are added
+
 ## What's Changed
-* 
+* `LazyStackInventory<T>` add implementation refactor
+  * Added protected helper `AddItem(T item, int amount)` to centralize inventory-wide add behavior and `OnAdd` event dispatch for successful additions
+  * Added protected helper `AddItemAt(T item, int index, int amount)` to centralize add-at-index behavior and `OnAdd` event dispatch for successful additions
+  * `Add(T item, int amount)`, `TryAdd(T item, int amount)`, `AddAt(T item, int index, int amount)`, and `TryAddAt(T item, int index, int amount)` now share the centralized add helpers
 
 ## What's Removed
 * 
 
 ## What's Fixed
-* 
+* Added unit-test coverage for `TryAdd` and `TryAddAt` success/failure and argument-validation behavior
 
 ## Known Issues
 * **No support for structs or value types** 

--- a/src/Containers/Interfaces/ILazyStackInventory.cs
+++ b/src/Containers/Interfaces/ILazyStackInventory.cs
@@ -98,6 +98,13 @@ namespace TheChest.Inventories.Containers.Interfaces
         /// <returns>true if the <paramref name="item"/> can be added at the specified <paramref name="index"/> for the given <paramref name="amount"/>; otherwise, false.</returns>
         bool CanAddAt(T item, int index, int amount = 1);
         /// <summary>
+        /// Attempts to add the specified amount of <paramref name="item"/> to the inventory.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="amount">The amount to add.</param>
+        /// <returns><see langword="true"/> if the requested <paramref name="amount"/> was added; otherwise, <see langword="false"/>.</returns>
+        bool TryAdd(T item, int amount);
+        /// <summary>
         /// Adds items inside the inventory
         /// </summary>
         /// <param name="item">Array of item of the same type wich will be added to inventory</param>
@@ -112,6 +119,14 @@ namespace TheChest.Inventories.Containers.Interfaces
         /// <param name="amount">amount of the item</param>
         /// <returns>Returns the amount of items that couldn't be added</returns>
         int AddAt(T item, int index, int amount);
+        /// <summary>
+        /// Attempts to add the specified amount of <paramref name="item"/> at the given <paramref name="index"/>.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="index">The slot index where the item should be added.</param>
+        /// <param name="amount">The amount to add.</param>
+        /// <returns><see langword="true"/> if the requested <paramref name="amount"/> was added at <paramref name="index"/>; otherwise, <see langword="false"/>.</returns>
+        bool TryAddAt(T item, int index, int amount);
         /// <summary>
         /// Checks if an item can be replaced in a specific slot
         /// </summary>

--- a/src/Containers/LazyStackInventory.Add.cs
+++ b/src/Containers/LazyStackInventory.Add.cs
@@ -74,6 +74,54 @@ namespace TheChest.Inventories.Containers
             return this.slots[index].CanAdd(item, amount);
         }
 
+
+        /// <summary>
+        /// Adds the specified amount of <paramref name="item"/> to the inventory using the slot add order.
+        /// </summary>
+        /// <param name="item">Item to be added to the inventory.</param>
+        /// <param name="amount">Amount of the item to add.</param>
+        /// <returns>Returns the amount of items that could not be added.</returns>
+        protected int AddItem(T item, int amount)
+        {
+            var events = new List<LazyStackInventoryAddItemEventData<T>>(amount);
+            var indexes = this.slots.GetAddOrderIndexes(item, amount);
+
+            foreach (var index in indexes)
+            {
+                var slot = this.slots[index];
+
+                var toAddAmount = Math.Min(amount, slot.AvailableAmount);
+
+                var notAddedAmount = slot.Add(item, toAddAmount);
+                var addedItemsCount = toAddAmount - notAddedAmount;
+
+                if (addedItemsCount <= 0)
+                    continue;
+
+                events.Add(new LazyStackInventoryAddItemEventData<T>(item, index, addedItemsCount));
+
+                amount -= addedItemsCount;
+                if (amount == 0)
+                    break;
+            }
+
+            if (events.Count > 0)
+                this.OnAdd?.Invoke(this, new LazyStackInventoryAddEventArgs<T>(events));
+
+            return amount;
+        }
+
+
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When <paramref name="amount"/> is less than or equal to zero.</exception>
+        public virtual bool TryAdd(T item, int amount)
+        {
+            if (!this.CanAdd(item, amount))
+                return false;
+
+            return this.AddItem(item, amount) == 0;
+        }
         /// <summary>
         /// Adds an item to the first available slot
         /// </summary>
@@ -108,32 +156,35 @@ namespace TheChest.Inventories.Containers
                 throw new InvalidOperationException(LazyStackInventoryErrors.InventoryIsFull);
             //TODO: add check for available space and throw exception if there is not enough space to add the items
 
-            var events = new List<LazyStackInventoryAddItemEventData<T>>(amount);
-            var indexes = this.slots.GetAddOrderIndexes(item, amount);
+            return this.AddItem(item, amount);
+        }
 
-            foreach (var index in indexes)
-            {
-                var slot = this.slots[index];
+        /// <summary>
+        /// Adds the specified amount of <paramref name="item"/> to the slot at <paramref name="index"/>.
+        /// </summary>
+        /// <param name="item">Item to be added to the slot.</param>
+        /// <param name="index">Index of the slot that will receive the item.</param>
+        /// <param name="amount">Amount of the item to add.</param>
+        /// <returns>Returns the amount of items that could not be added to the slot.</returns>
+        protected int AddItemAt(T item, int index, int amount)
+        {
+            var notAdded = this.slots[index].Add(item, amount);
+            if (notAdded < amount)
+                this.OnAdd?.Invoke(this, (item, index, amount - notAdded));
 
-                var toAddAmount = Math.Min(amount, slot.AvailableAmount);
+            return notAdded;
+        }
 
-                var notAddedAmount = slot.Add(item, toAddAmount);
-                var addedItemsCount = toAddAmount - notAddedAmount;
 
-                if (addedItemsCount <= 0)
-                    continue;
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When <paramref name="amount"/> is less than or equal to zero, or <paramref name="index"/> is out of range.</exception>
+        public virtual bool TryAddAt(T item, int index, int amount)
+        {
+            if (!this.CanAddAt(item, index, amount))
+                return false;
 
-                events.Add(new LazyStackInventoryAddItemEventData<T>(item, index, addedItemsCount));
-
-                amount -= addedItemsCount;
-                if (amount == 0)
-                    break;
-            }
-
-            if (events.Count > 0)
-                this.OnAdd?.Invoke(this, new LazyStackInventoryAddEventArgs<T>(events));
-
-            return amount;
+            return this.AddItemAt(item, index, amount) == 0;
         }
         /// <inheritdoc/>
         /// <remarks>
@@ -150,11 +201,7 @@ namespace TheChest.Inventories.Containers
             if (index < 0 || index > this.Size)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            var notAdded = this.slots[index].Add(item, amount);
-            if (notAdded < amount)
-                this.OnAdd?.Invoke(this, (item, index, amount - notAdded));
-
-            return notAdded;
+            return this.AddItemAt(item, index, amount);
         }
     }
 }

--- a/tests/Containers/LazyStackInventory/LazyStackInventoryTests.TryAdd.cs
+++ b/tests/Containers/LazyStackInventory/LazyStackInventoryTests.TryAdd.cs
@@ -1,0 +1,95 @@
+﻿using TheChest.Tests.Common.Extensions.Containers;
+using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
+{
+    public partial class LazyStackInventoryTests<T>
+    {
+        [Test]
+        public void TryAdd_NullItem_ThrowsArgumentNullException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryAdd(default!, 1),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void TryAdd_ZeroOrLessAmount_ThrowsArgumentOutOfRangeException(int amount)
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+
+            Assert.That(
+                () => inventory.TryAdd(item, amount),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("amount")
+            );
+        }
+
+        [Test]
+        public void TryAdd_NotEnoughSpace_ReturnsFalse()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var randomItems = this.itemFactory.CreateManyRandom(size - 1);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, stackSize, randomItems);
+
+            var item = this.itemFactory.CreateDefault();
+            var amount = stackSize + this.random.Next(1, 5);
+
+            var result = inventory.TryAdd(item, amount);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAdd_NotEnoughSpace_DoesNotAddItem()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var randomItems = this.itemFactory.CreateManyRandom(size - 1);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, stackSize, randomItems);
+
+            var initialSlots = inventory.GetSlots().Select(slot => (slot.GetContent(), slot.Amount)).ToArray();
+            var item = this.itemFactory.CreateDefault();
+            var amount = stackSize + this.random.Next(1, 5);
+
+            inventory.TryAdd(item, amount);
+
+            Assert.That(
+                inventory.GetSlots().Select(slot => (slot.GetContent(), slot.Amount)).ToArray(),
+                Is.EqualTo(initialSlots)
+            );
+        }
+
+        [Test]
+        public void TryAdd_NotEnoughSpace_DoesNotCallOnAddEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var randomItems = this.itemFactory.CreateManyRandom(size - 1);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, stackSize, randomItems);
+            var item = this.itemFactory.CreateDefault();
+            var amount = stackSize + this.random.Next(1, 5);
+
+            inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd should not be called when TryAdd returns false.");
+
+            inventory.TryAdd(item, amount);
+        }
+
+        [Test]
+        public void TryAdd_EnoughSpace_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+            var amount = this.random.Next(1, stackSize);
+
+            var result = inventory.TryAdd(item, amount);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}

--- a/tests/Containers/LazyStackInventory/LazyStackInventoryTests.TryAddAt.cs
+++ b/tests/Containers/LazyStackInventory/LazyStackInventoryTests.TryAddAt.cs
@@ -1,0 +1,90 @@
+﻿using TheChest.Tests.Common.Extensions.Containers;
+
+namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
+{
+    public partial class LazyStackInventoryTests<T>
+    {
+        [Test]
+        public void TryAddAt_NullItem_ThrowsArgumentNullException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryAddAt(default!, 0, 1),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void TryAddAt_ZeroOrLessAmount_ThrowsArgumentOutOfRangeException(int amount)
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+
+            Assert.That(
+                () => inventory.TryAddAt(item, 0, amount),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("amount")
+            );
+        }
+
+        [TestCase(-1)]
+        [TestCase(MAX_SIZE_TEST)]
+        public void TryAddAt_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+
+            Assert.That(
+                () => inventory.TryAddAt(item, index, 1),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void TryAddAt_SlotCannotAdd_ReturnsFalse()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var randomItems = this.itemFactory.CreateManyRandom(size);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, stackSize, randomItems);
+
+            var item = this.itemFactory.CreateDefault();
+            var index = this.random.Next(0, size);
+
+            var result = inventory.TryAddAt(item, index, 1);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAddAt_SlotCannotAdd_DoesNotCallOnAddEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var randomItems = this.itemFactory.CreateManyRandom(size);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, stackSize, randomItems);
+
+            var item = this.itemFactory.CreateDefault();
+            var index = this.random.Next(0, size);
+            inventory.OnAdd += (sender, args) => Assert.Fail("OnAdd should not be called when TryAddAt returns false.");
+
+            inventory.TryAddAt(item, index, 1);
+        }
+
+        [Test]
+        public void TryAddAt_SlotCanAdd_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var item = this.itemFactory.CreateDefault();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize);
+
+            var result = inventory.TryAddAt(item, index, amount);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide boolean-try semantics for adding items (`TryAdd` / `TryAddAt`) so callers can attempt adds without handling exceptions or checking remaining amounts.
- Consolidate repeated slot-add logic into shared helper methods to centralize event firing and reduce duplication.

### Description
- Added `TryAdd(T item, int amount)` and `TryAddAt(T item, int index, int amount)` signatures and XML docs to `ILazyStackInventory`.
- Implemented `AddItem` and `AddItemAt` protected helpers in `LazyStackInventory.Add.cs` which perform slot iteration/adding and raise the `OnAdd` event with `LazyStackInventoryAddItemEventData<T>` / `LazyStackInventoryAddEventArgs<T>` as appropriate.
- Implemented `TryAdd` and `TryAddAt` to use `CanAdd` / `CanAddAt` for pre-checks and the new helpers to perform the add and return success as a boolean.
- Refactored `Add(T item, int amount)` and `AddAt(T item, int index, int amount)` to delegate to the new helper methods.

### Testing
- Built the solution with `dotnet build` successfully. 
- Ran unit tests with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1439f0df088323993aaa78fbe30c3f)