### PR TITLE
Add unit tests for InventorySlot<T>.TryAdd and Inventory<T>.TryAdd

### DIFF
--- a/tests/Containers/Inventory/InventoryTests.TryAdd.cs
+++ b/tests/Containers/Inventory/InventoryTests.TryAdd.cs
@@ -1,0 +1,129 @@
+﻿using TheChest.Inventories.Slots.Interfaces;
+using TheChest.Tests.Common.Extensions.Containers;
+using TheChest.Tests.Common.Extensions.Slots;
+using TheChest.Tests.Common.Extensions;
+
+namespace TheChest.Inventories.Tests.Containers.Inventory
+{
+    public partial class InventoryTests<T>
+    {
+        [Test]
+        public void TryAddItems_EmptyItemsArray_ThrowsArgumentException()
+        {
+            var inventory = this.inventoryFactory.EmptyContainer(this.GenerateRandomSize());
+
+            Assert.That(
+                () => inventory.TryAdd(Array.Empty<T>()),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("items")
+            );
+        }
+
+        [Test]
+        public void TryAddItems_ArrayContainingNullItems_ThrowsArgumentNullException()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var items = this.itemFactory
+                .CreateManyRandom(this.random.Next(2, size))
+                .Append(default!)
+                .ToArray();
+            items.Shuffle();
+
+            Assert.That(
+                () => inventory.TryAdd(items),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("items")
+            );
+        }
+
+        [Test]
+        public void TryAddItems_ItemsBiggerThanInventorySize_ReturnsFalse()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var items = this.itemFactory.CreateMany(size + 1);
+
+            var result = inventory.TryAdd(items);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAddItems_NotEnoughAvailableSlots_CallsOnAddEventForAddedItems()
+        {
+            var size = this.GenerateRandomSize();
+            var items = this.itemFactory.CreateMany(size - 1);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, items);
+            var addItems = this.itemFactory.CreateManyRandom(2);
+
+            var called = false;
+            inventory.OnAdd += (_, _) => called = true;
+
+            inventory.TryAdd(addItems);
+
+            Assert.That(called, Is.True);
+        }
+
+        [Test]
+        public void TryAddItems_NotEnoughAvailableSlots_AddsOnlyUntilNoSlotsAvailable()
+        {
+            var size = this.GenerateRandomSize();
+            var existingItems = this.itemFactory.CreateMany(size - 1);
+            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, existingItems);
+            var addItems = this.itemFactory.CreateManyRandom(2);
+            var slotsBefore = inventory.GetSlots().Select(slot => slot.GetContent()).ToArray();
+
+            inventory.TryAdd(addItems);
+
+            var filledAfter = inventory.GetSlots().Count(slot => slot.IsFull);
+
+            Assert.That(filledAfter, Is.EqualTo(slotsBefore.Count(x => x is not null) + 1));
+        }
+
+        [Test]
+        public void TryAddItems_EnoughAvailableSlots_AddsAllItems()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var addSize = this.random.Next(1, size);
+            var items = this.itemFactory.CreateMany(addSize);
+
+            inventory.TryAdd(items);
+
+            Assert.That(
+                inventory.GetSlots().Take(addSize).Select(slot => slot.GetContent()),
+                Is.EqualTo(items)
+            );
+        }
+
+        [Test]
+        public void TryAddItems_EnoughAvailableSlots_ReturnsTrue()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            var result = inventory.TryAdd(this.itemFactory.CreateMany(1));
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryAddItems_EnoughAvailableSlots_CallsOnAddEvent()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var addSize = this.random.Next(1, size);
+            var items = this.itemFactory.CreateMany(addSize);
+
+            var called = false;
+            inventory.OnAdd += (sender, args) =>
+            {
+                Assert.That(sender, Is.EqualTo(inventory));
+                called = args.Data.Select(x => x.Item).SequenceEqual(items);
+            };
+
+            inventory.TryAdd(items);
+
+            Assert.That(called, Is.True);
+        }
+    }
+}

--- a/tests/Slots/InventorySlot/InventorySlotTests.try_add.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.try_add.cs
@@ -1,0 +1,58 @@
+﻿using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Slots.InventorySlot
+{
+    public partial class InventorySlotTests<T>
+    {
+        [Test]
+        public void TryAdd_NullItem_ThrowsArgumentNullException()
+        {
+            var slot = this.slotFactory.Empty();
+
+            Assert.That(() => slot.TryAdd(default!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void TryAdd_FullSlot_ReturnsFalse()
+        {
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(item);
+
+            var result = slot.TryAdd(this.itemFactory.CreateRandom());
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAdd_FullSlot_DoesNotChangeContent()
+        {
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(item);
+
+            slot.TryAdd(this.itemFactory.CreateRandom());
+
+            Assert.That(slot.GetContent(), Is.EqualTo(item));
+        }
+
+        [Test]
+        public void TryAdd_EmptySlot_ChangesContent()
+        {
+            var slot = this.slotFactory.Empty();
+            var item = this.itemFactory.CreateDefault();
+
+            slot.TryAdd(item);
+
+            Assert.That(slot.GetContent(), Is.EqualTo(item));
+        }
+
+        [Test]
+        public void TryAdd_EmptySlot_ReturnsTrue()
+        {
+            var slot = this.slotFactory.Empty();
+
+            var result = slot.TryAdd(this.itemFactory.CreateDefault());
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for add semantics by exercising `InventorySlot<T>.TryAdd` and `Inventory<T>.TryAdd(params T[])` behaviors including validation, return values, and event firing.

### Description
- Added `tests/Slots/InventorySlot/InventorySlotTests.try_add.cs` with tests for null argument validation, full-slot behavior (no change + returns false), and successful add on empty slots (content change + returns true). 
- Added `tests/Containers/Inventory/InventoryTests.TryAdd.cs` with tests for empty/null input validation, items larger than inventory size, partial-add behavior when capacity is constrained (ensures only available slots are filled and `OnAdd` is invoked for added items), and successful-add behavior including return value and `OnAdd` invocation.
- Included the repository test extensions import to support test helpers used by the new tests.

### Testing
- Ran targeted test executions of the new TryAdd tests using `dotnet test tests/TheChest.Inventories.Tests.csproj` with several `--filter` expressions to isolate the added tests; tests were iterated and adjusted until all targeted cases passed.
- Example commands executed: `dotnet test tests/TheChest.Inventories.Tests.csproj --filter "Name~TryAddItems_EnoughAvailableSlots_ReturnsTrue|Name~TryAddItems_NotEnoughAvailableSlots_AddsOnlyUntilNoSlotsAvailable|Name~TryAdd_EmptySlot_ChangesContent"` and `dotnet test tests/TheChest.Inventories.Tests.csproj --filter "Name~TryAddItems_ItemsBiggerThanInventorySize_ReturnsFalse|Name~TryAdd_EmptySlot_ReturnsTrue"`, and the final targeted test runs completed successfully.
- Verified the new tests appear in the test list via `dotnet test --list-tests` and the added tests executed and passed in the test runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171c16bed48323ab8beb32f437bf1b)