### PR TITLE
Add `TryAdd(T[])` to InventoryStackSlot with validation and tests

### DIFF
--- a/src/Slots/Interfaces/IInventoryStackSlot.cs
+++ b/src/Slots/Interfaces/IInventoryStackSlot.cs
@@ -41,6 +41,15 @@ namespace TheChest.Inventories.Slots.Interfaces
         /// <param name="items">items to be added to the slot</param>
         /// <returns>The items that were not added to the slot</returns>
         T[] Add(T[] items);
+        /// <summary>
+        /// Tries to add an array of items to the slot.
+        /// </summary>
+        /// <remarks>
+        /// This method contract will change to have params instead of array in the future, but for now it will be an array for compatibility reasons.
+        /// </remarks>
+        /// <param name="items">items to be added to the slot</param>
+        /// <returns><see langword="true"/> if all items were added to the slot; otherwise <see langword="false"/></returns>
+        bool TryAdd(T[] items);
 
         /// <summary>
         /// Checks if is possible to replace an item

--- a/src/Slots/InventoryStackSlot.cs
+++ b/src/Slots/InventoryStackSlot.cs
@@ -156,6 +156,25 @@ namespace TheChest.Inventories.Slots
             return items;
         }
         /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException">When <paramref name="items"/> is <see langword="null"/> or contains <see langword="null"/> values.</exception>
+        public virtual bool TryAdd(T[] items)
+        {
+            if (items is null || items.ContainsNull())
+                throw new ArgumentNullException(nameof(items));
+
+            if (this.IsFull)
+                return false;
+            if (items.Length > this.AvailableAmount)
+                return false;
+            if (!items.HasAllEqual())
+                return false;
+            if (!this.IsEmpty && !this.Contains(items))
+                return false;
+
+            this.AddItems(ref items);
+            return true;
+        }
+        /// <inheritdoc/>
         /// <exception cref="ArgumentNullException">when <paramref name="item"/> is <see langword="null"/></exception>
         /// <exception cref="InvalidOperationException">When the slot is full or when trying to add an item that is different from the items already in the slot</exception>
         public virtual bool Add(T item)

--- a/tests/Slots/Interfaces/IInventoryStackSlot/IInventoryStackSlotTests.try_add_items.cs
+++ b/tests/Slots/Interfaces/IInventoryStackSlot/IInventoryStackSlotTests.try_add_items.cs
@@ -1,0 +1,108 @@
+﻿using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Slots.Interfaces
+{
+    public partial class IInventoryStackSlotTests<T>
+    {
+        [Test]
+        public void TryAddItems_NullItems_ThrowsArgumentNullException()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+
+            Assert.That(() => slot.TryAdd(null!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void TryAddItems_ArrayContainingNull_ThrowsArgumentNullException()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = new T[] { default! };
+
+            Assert.That(() => slot.TryAdd(items), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void TryAddItems_FullSlot_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.Full(slotItems);
+            var addingItems = this.itemFactory.CreateMany(1);
+
+            var result = slot.TryAdd(addingItems);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAddItems_FullSlot_DoesNotAddItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.Full(slotItems);
+            var addingItems = this.itemFactory.CreateMany(1);
+
+            slot.TryAdd(addingItems);
+
+            Assert.That(slot.GetContents(), Is.EquivalentTo(slotItems));
+        }
+
+        [Test]
+        public void TryAddItems_SlotWithDifferentItems_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var currentAmount = this.random.Next(1, stackSize - 1);
+            var slotItems = this.itemFactory.CreateMany(currentAmount);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var addingItems = this.itemFactory.CreateManyRandom(1);
+
+            var result = slot.TryAdd(addingItems);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAddItems_NotEnoughCapacity_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var currentAmount = this.random.Next(1, stackSize - 1);
+            var slotItems = this.itemFactory.CreateMany(currentAmount);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var addingItems = this.itemFactory.CreateMany(stackSize - currentAmount + 1);
+
+            var result = slot.TryAdd(addingItems);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAddItems_NotEnoughCapacity_DoesNotAddItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var currentAmount = this.random.Next(1, stackSize - 1);
+            var slotItems = this.itemFactory.CreateMany(currentAmount);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var addingItems = this.itemFactory.CreateMany(stackSize - currentAmount + 1);
+
+            slot.TryAdd(addingItems);
+
+            Assert.That(slot.GetContents(), Is.EquivalentTo(slotItems));
+        }
+
+        [Test]
+        public void TryAddItems_ValidItems_ReturnsTrue()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var currentAmount = this.random.Next(1, stackSize - 1);
+            var slotItems = this.itemFactory.CreateMany(currentAmount);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var addingItems = this.itemFactory.CreateMany(stackSize - currentAmount);
+
+            var result = slot.TryAdd(addingItems);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a non-throwing array add API for stack slots to mirror container `TryAdd` semantics and avoid exceptions for routine capacity checks. 
- Ensure callers can attempt to add multiple equal items atomically while keeping slot mutation predictable when the add cannot be performed.

### Description
- Add `bool TryAdd(T[] items)` to `IInventoryStackSlot<T>` to expose the new non-throwing overload.
- Implement `InventoryStackSlot<T>.TryAdd(T[] items)` to validate inputs and return `false` for full slots, insufficient capacity, mixed/different items, or other invalid add conditions, and to throw `ArgumentNullException` when the array is `null` or contains `null` values. 
- On successful validation the implementation uses the protected `AddItems(ref items)` method to perform the add and returns `true` without returning leftover items. 
- Add unit tests in `tests/Slots/Interfaces/IInventoryStackSlot/IInventoryStackSlotTests.try_add_items.cs` covering null validation, failure conditions, non-mutation on failure, and the successful add path.

### Testing
- Ran the test suite with `dotnet test --nologo --verbosity minimal` and the run completed successfully.
- Test summary: Passed 679, Failed 0, Skipped 2, Total 681.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171f10f8ac8323880027a82a1dd04e)