### PR TITLE
Add TryAdd to IInventoryLazyStackSlot/InventoryLazyStackSlot with tests

### DIFF
--- a/src/Slots/Interfaces/IInventoryLazyStackSlot.cs
+++ b/src/Slots/Interfaces/IInventoryLazyStackSlot.cs
@@ -24,6 +24,13 @@ namespace TheChest.Inventories.Slots.Interfaces
         /// <returns>true if is possible to add the amount of the <paramref name="item"/> inside the slot</returns>
         bool CanAdd(T item, int amount = 1);
         /// <summary>
+        /// Tries to add an amount of items to the current slot.
+        /// </summary>
+        /// <param name="item">The item to be added.</param>
+        /// <param name="amount">The amount of items to be added.</param>
+        /// <returns><see langword="true"/> when the items were added, otherwise <see langword="false"/>.</returns>
+        bool TryAdd(T item, int amount = 1);
+        /// <summary>
         /// Add an amount of items inside the current slot
         /// </summary>
         /// <param name="item">The item to be added </param>

--- a/src/Slots/InventoryLazyStackSlot.cs
+++ b/src/Slots/InventoryLazyStackSlot.cs
@@ -89,6 +89,26 @@ namespace TheChest.Inventories.Slots
         /// <inheritdoc/>
         /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/></exception>
         /// <exception cref="ArgumentOutOfRangeException">When <paramref name="amount"/> is smaller than zero</exception>
+        public virtual bool TryAdd(T item, int amount = 1)
+        {
+            if (item.IsNull())
+                throw new ArgumentNullException(nameof(item));
+            if (amount <= 0 || amount > this.MaxAmount)
+                throw new ArgumentOutOfRangeException(nameof(amount));
+
+            if (this.IsFull)
+                return false;
+            if (!this.IsEmpty && !this.Content.Equals(item))
+                return false;
+            if (amount > this.AvailableAmount)
+                return false;
+
+            this.AddItems(item, amount);
+            return true;
+        }
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException">When <paramref name="item"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentOutOfRangeException">When <paramref name="amount"/> is smaller than zero</exception>
         public virtual int Add(T item, int amount = 1)
         {
             if (item.IsNull())

--- a/src/Slots/InventoryLazyStackSlot.cs
+++ b/src/Slots/InventoryLazyStackSlot.cs
@@ -93,7 +93,7 @@ namespace TheChest.Inventories.Slots
         {
             if (item.IsNull())
                 throw new ArgumentNullException(nameof(item));
-            if (amount <= 0 || amount > this.MaxAmount)
+            if (amount <= 0)
                 throw new ArgumentOutOfRangeException(nameof(amount));
 
             if (this.IsFull)

--- a/tests/Slots/Interfaces/IInventoryLazyStackSlot/IInventoryLazyStackSlotTests.try_add.cs
+++ b/tests/Slots/Interfaces/IInventoryLazyStackSlot/IInventoryLazyStackSlotTests.try_add.cs
@@ -61,6 +61,19 @@
         }
 
         [Test]
+        public void TryAdd_AmountBiggerThanStackSizeOnEmptySlot_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Empty(stackSize);
+            var addAmount = stackSize + this.random.Next(1, 5);
+
+            var result = slot.TryAdd(item, addAmount);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
         public void TryAdd_ValidInput_ReturnsTrue()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);

--- a/tests/Slots/Interfaces/IInventoryLazyStackSlot/IInventoryLazyStackSlotTests.try_add.cs
+++ b/tests/Slots/Interfaces/IInventoryLazyStackSlot/IInventoryLazyStackSlotTests.try_add.cs
@@ -1,0 +1,76 @@
+﻿namespace TheChest.Inventories.Tests.Slots.Interfaces
+{
+    public partial class IInventoryLazyStackSlotTests<T>
+    {
+        [Test]
+        public void TryAdd_NullItem_ThrowsArgumentNullException()
+        {
+            var slot = this.slotFactory.Empty(this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST));
+
+            Assert.Throws<ArgumentNullException>(() => slot.TryAdd(default!, 1));
+        }
+
+        [TestCase(-1)]
+        [TestCase(0)]
+        public void TryAdd_InvalidAmount_ThrowsArgumentOutOfRangeException(int amount)
+        {
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Empty(this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => slot.TryAdd(item, amount));
+        }
+
+        [Test]
+        public void TryAdd_FullSlot_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.FullSlot(item, stackSize);
+
+            var result = slot.TryAdd(item, 1);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAdd_NotEmptySlotAndDifferentItem_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var amount = this.random.Next(1, stackSize);
+            var item = this.itemFactory.CreateDefault();
+            var newItem = this.itemFactory.CreateRandom();
+            var slot = this.slotFactory.WithItem(item, amount, stackSize);
+
+            var result = slot.TryAdd(newItem, 1);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAdd_AmountBiggerThanAvailableAmount_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var amount = this.random.Next(1, stackSize);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.WithItem(item, amount, stackSize);
+            var addAmount = slot.AvailableAmount + 1;
+
+            var result = slot.TryAdd(item, addAmount);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryAdd_ValidInput_ReturnsTrue()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Empty(stackSize);
+            var amount = this.random.Next(1, stackSize);
+
+            var result = slot.TryAdd(item, amount);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}

--- a/tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_add.cs
+++ b/tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_add.cs
@@ -9,7 +9,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryLazyStackSlot
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var item = this.itemFactory.CreateDefault();
-            var slot = this.slotFactory.Full(item, stackSize);
+            var slot = this.slotFactory.FullSlot(item, stackSize);
 
             slot.TryAdd(item, 1);
 
@@ -42,6 +42,19 @@ namespace TheChest.Inventories.Tests.Slots.InventoryLazyStackSlot
             slot.TryAdd(item, addAmount);
 
             Assert.That(slot.Amount, Is.EqualTo(amount));
+        }
+
+        [Test]
+        public void TryAdd_AmountBiggerThanStackSizeOnEmptySlot_DoesNotChangeAmount()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Empty(stackSize);
+            var addAmount = stackSize + this.random.Next(1, 5);
+
+            slot.TryAdd(item, addAmount);
+
+            Assert.That(slot.Amount, Is.Zero);
         }
 
         [Test]

--- a/tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_add.cs
+++ b/tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_add.cs
@@ -1,0 +1,61 @@
+﻿using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Slots.InventoryLazyStackSlot
+{
+    public partial class InventoryLazyStackSlotTests<T>
+    {
+        [Test]
+        public void TryAdd_FullSlot_DoesNotChangeAmount()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(item, stackSize);
+
+            slot.TryAdd(item, 1);
+
+            Assert.That(slot.Amount, Is.EqualTo(stackSize));
+        }
+
+        [Test]
+        public void TryAdd_NotEmptySlotAndDifferentItem_DoesNotChangeContent()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var amount = this.random.Next(1, stackSize);
+            var item = this.itemFactory.CreateDefault();
+            var newItem = this.itemFactory.CreateRandom();
+            var slot = this.slotFactory.WithItem(item, amount, stackSize);
+
+            slot.TryAdd(newItem, 1);
+
+            Assert.That(slot.GetContent(), Is.EqualTo(item));
+        }
+
+        [Test]
+        public void TryAdd_AmountBiggerThanAvailableAmount_DoesNotChangeAmount()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var amount = this.random.Next(1, stackSize);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.WithItem(item, amount, stackSize);
+            var addAmount = slot.AvailableAmount + 1;
+
+            slot.TryAdd(item, addAmount);
+
+            Assert.That(slot.Amount, Is.EqualTo(amount));
+        }
+
+        [Test]
+        public void TryAdd_ValidInput_AddsItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var amount = this.random.Next(1, stackSize);
+            var addAmount = this.random.Next(1, stackSize - amount + 1);
+            var item = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.WithItem(item, amount, stackSize);
+
+            slot.TryAdd(item, addAmount);
+
+            Assert.That(slot.Amount, Is.EqualTo(amount + addAmount));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a non-throwing add variant for lazy stack slots that validates inputs and only mutates state when the add can succeed.
- Match existing `TryAdd` semantics used by container APIs so callers can attempt adds without catching exceptions.

### Description
- Added `bool TryAdd(T item, int amount = 1)` to `IInventoryLazyStackSlot<T>`.
- Implemented `TryAdd` in `InventoryLazyStackSlot<T>` with argument validation that throws for `null` item or invalid `amount`, returns `false` (without mutating state) when the slot is full, contains a different item, or lacks available capacity, and calls the protected `AddItems` method on success returning `true`.
- Added interface-level tests in `tests/Slots/Interfaces/IInventoryLazyStackSlot/IInventoryLazyStackSlotTests.try_add.cs` covering invalid arguments, failure branches, and success return behavior.
- Added concrete slot tests in `tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_add.cs` verifying state is unchanged on failure and updated correctly on success.

### Testing
- Ran the targeted test suite with `dotnet test tests/TheChest.Inventories.Tests.csproj --filter "TryAdd" -v minimal` and the filtered tests passed (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171fc460608323b9fe964fe463a460)