### PR TITLE
Add TryReplace unit tests

### DIFF
--- a/tests/Containers/Inventory/InventoryTests.TryReplace.cs
+++ b/tests/Containers/Inventory/InventoryTests.TryReplace.cs
@@ -1,0 +1,174 @@
+﻿using TheChest.Tests.Common.Extensions.Containers;
+
+namespace TheChest.Inventories.Tests.Containers.Inventory
+{
+    public partial class InventoryTests<T>
+    {
+        [Test]
+        public void TryReplace_NullItem_ThrowsArgumentNullException()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            Assert.That(
+                () => inventory.TryReplace(default!, 0, out _),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [TestCase(-1)]
+        [TestCase(MAX_SIZE_TEST)]
+        public void TryReplace_InvalidSlotIndex_ThrowsArgumentOutOfRangeException(int index)
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            Assert.That(
+                () => inventory.TryReplace(this.itemFactory.CreateDefault(), index, out _),
+                Throws.Exception.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void TryReplace_IndexEqualToSize_ThrowsArgumentOutOfRangeException()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+
+            Assert.That(
+                () => inventory.TryReplace(this.itemFactory.CreateDefault(), size, out _),
+                Throws.Exception.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_AddsItemToSlot()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var randomIndex = this.random.Next(0, size);
+            var item = this.itemFactory.CreateDefault();
+
+            inventory.TryReplace(item, randomIndex, out _);
+
+            Assert.That(inventory.GetItem<T>(randomIndex), Is.EqualTo(item));
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_CallsOnReplaceEventWithEmptyOldItem()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var randomIndex = this.random.Next(0, size);
+            var item = this.itemFactory.CreateDefault();
+            var calledWithExpectedData = false;
+
+            inventory.OnReplace += (sender, args) =>
+            {
+                var data = args.Data.Single();
+                calledWithExpectedData =
+                    sender == inventory &&
+                    data.Index == randomIndex &&
+                    data.OldItem is null &&
+                    data.NewItem!.Equals(item);
+            };
+
+            inventory.TryReplace(item, randomIndex, out _);
+
+            Assert.That(calledWithExpectedData, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsOldItemToNull()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var randomIndex = this.random.Next(0, size);
+            var item = this.itemFactory.CreateDefault();
+
+            inventory.TryReplace(item, randomIndex, out var oldItem);
+
+            Assert.That(oldItem, Is.Null);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReturnsTrue()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var randomIndex = this.random.Next(0, size);
+            var item = this.itemFactory.CreateDefault();
+
+            var result = inventory.TryReplace(item, randomIndex, out _);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_FullSlot_ReplacesItemInSlot()
+        {
+            var size = this.GenerateRandomSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, initialItem);
+            var randomIndex = this.random.Next(0, size);
+            var newItem = this.itemFactory.CreateRandom();
+
+            inventory.TryReplace(newItem, randomIndex, out _);
+
+            Assert.That(inventory.GetItem(randomIndex), Is.EqualTo(newItem));
+        }
+
+        [Test]
+        public void TryReplace_FullSlot_CallsOnReplaceEvent()
+        {
+            var size = this.GenerateRandomSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, initialItem);
+            var randomIndex = this.random.Next(0, size);
+            var newItem = this.itemFactory.CreateRandom();
+            var calledWithExpectedData = false;
+
+            inventory.OnReplace += (sender, args) =>
+            {
+                var data = args.Data.Single();
+                calledWithExpectedData =
+                    sender == inventory &&
+                    data.Index == randomIndex &&
+                    data.OldItem!.Equals(initialItem) &&
+                    data.NewItem!.Equals(newItem);
+            };
+
+            inventory.TryReplace(newItem, randomIndex, out _);
+
+            Assert.That(calledWithExpectedData, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_FullSlot_SetsOldItemToPreviousItem()
+        {
+            var size = this.GenerateRandomSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, initialItem);
+            var randomIndex = this.random.Next(0, size);
+            var newItem = this.itemFactory.CreateRandom();
+
+            inventory.TryReplace(newItem, randomIndex, out var oldItem);
+
+            Assert.That(oldItem, Is.EqualTo(initialItem));
+        }
+
+        [Test]
+        public void TryReplace_FullSlot_ReturnsTrue()
+        {
+            var size = this.GenerateRandomSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, initialItem);
+            var randomIndex = this.random.Next(0, size);
+            var newItem = this.itemFactory.CreateRandom();
+
+            var result = inventory.TryReplace(newItem, randomIndex, out _);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}

--- a/tests/Slots/InventorySlot/InventorySlotTests.try_replace.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.try_replace.cs
@@ -1,0 +1,87 @@
+﻿using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Slots.InventorySlot
+{
+    public partial class InventorySlotTests<T>
+    {
+        [Test]
+        public void TryReplace_NullItem_ThrowsArgumentNullException()
+        {
+            var slot = this.slotFactory.Empty();
+
+            Assert.That(
+                () => slot.TryReplace(default!, out _),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_AddsItem()
+        {
+            var slot = this.slotFactory.Empty();
+            var item = this.itemFactory.CreateDefault();
+
+            slot.TryReplace(item, out _);
+
+            Assert.That(slot.GetContent(), Is.EqualTo(item));
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsOldItemToNull()
+        {
+            var slot = this.slotFactory.Empty();
+            var item = this.itemFactory.CreateDefault();
+
+            slot.TryReplace(item, out var oldItem);
+
+            Assert.That(oldItem, Is.Null);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReturnsTrue()
+        {
+            var slot = this.slotFactory.Empty();
+            var item = this.itemFactory.CreateDefault();
+
+            var result = slot.TryReplace(item, out _);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_FullSlot_ReplacesItem()
+        {
+            var initialItem = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(initialItem);
+            var newItem = this.itemFactory.CreateRandom();
+
+            slot.TryReplace(newItem, out _);
+
+            Assert.That(slot.GetContent(), Is.EqualTo(newItem));
+        }
+
+        [Test]
+        public void TryReplace_FullSlot_SetsOldItemToPreviousItem()
+        {
+            var initialItem = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(initialItem);
+            var newItem = this.itemFactory.CreateRandom();
+
+            slot.TryReplace(newItem, out var oldItem);
+
+            Assert.That(oldItem, Is.EqualTo(initialItem));
+        }
+
+        [Test]
+        public void TryReplace_FullSlot_ReturnsTrue()
+        {
+            var initialItem = this.itemFactory.CreateDefault();
+            var slot = this.slotFactory.Full(initialItem);
+            var newItem = this.itemFactory.CreateRandom();
+
+            var result = slot.TryReplace(newItem, out _);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve coverage for the `TryReplace` behavior on both the container and slot implementations to validate null checks, index validation, event firing, `out oldItem` semantics and boolean return values.
- Ensure `Inventory.TryReplace` correctly forwards to the underlying slot and raises `OnReplace` with expected `InventoryReplaceEventData<T>`.
- Ensure `InventorySlot.TryReplace` preserves the documented semantics for empty and full slots, including returning `true` and returning the previous item via the `out` parameter.

### Description
- Added `tests/Containers/Inventory/InventoryTests.TryReplace.cs` which contains tests for `Inventory<T>.TryReplace` covering null item validation, invalid index and index==size checks, empty/full slot replacement, event payload assertions, `out` oldItem values, and return values.
- Added `tests/Slots/InventorySlot/InventorySlotTests.try_replace.cs` which contains tests for `InventorySlot<T>.TryReplace` covering null item validation, empty-slot behavior (adds item and sets `oldItem` to null), full-slot replacement, `out` oldItem contents, and boolean return semantics.
- Tests follow the repository conventions by using existing factories, `BaseTest<T>` infrastructure and the project’s test extension helpers, and are implemented as partial class files that extend the existing test fixtures.

### Testing
- Ran `dotnet test tests/TheChest.Inventories.Tests.csproj` and the test run passed with all tests green: `Passed: 730, Failed: 0, Skipped: 2, Total: 732`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26c380ed448323b838339b90491d09)