### PR TITLE
Add InventoryStackSlot TryReplace unit tests

### DIFF
--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.try_replace.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.try_replace.cs
@@ -1,0 +1,178 @@
+﻿using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
+{
+    public partial class InventoryStackSlotTests<T>
+    {
+        [Test]
+        public void TryReplace_NullItems_ThrowsArgumentNullException()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+
+            Assert.That(() => slot.TryReplace(null!, out _), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void TryReplace_ArrayContainingNull_ThrowsArgumentNullException()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = new T[] { default! };
+
+            Assert.That(() => slot.TryReplace(items, out _), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void TryReplace_EmptyItems_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var items = Array.Empty<T>();
+
+            var result = slot.TryReplace(items, out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_EmptyItems_SetsOldItemsToNull()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var items = Array.Empty<T>();
+
+            slot.TryReplace(items, out var oldItems);
+
+            Assert.That(oldItems, Is.Null);
+        }
+
+        [Test]
+        public void TryReplace_EmptyItems_DoesNotReplaceItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var items = Array.Empty<T>();
+
+            slot.TryReplace(items, out _);
+
+            Assert.That(slot.GetContents(), Is.EqualTo(slotItems));
+        }
+
+        [Test]
+        public void TryReplace_ItemsBiggerThanMaxAmount_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = this.itemFactory.CreateMany(stackSize + 1);
+
+            var result = slot.TryReplace(items, out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_ItemsBiggerThanMaxAmount_SetsOldItemsToNull()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = this.itemFactory.CreateMany(stackSize + 1);
+
+            slot.TryReplace(items, out var oldItems);
+
+            Assert.That(oldItems, Is.Null);
+        }
+
+        [Test]
+        public void TryReplace_ItemsWithDifferentValues_ReturnsFalse()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = new[] { this.itemFactory.CreateDefault(), this.itemFactory.CreateRandom() };
+
+            var result = slot.TryReplace(items, out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReturnsTrue()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = this.itemFactory.CreateMany(this.random.Next(1, stackSize));
+
+            var result = slot.TryReplace(items, out _);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsOldItemsToEmptyArray()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = this.itemFactory.CreateMany(this.random.Next(1, stackSize));
+
+            slot.TryReplace(items, out var oldItems);
+
+            Assert.That(oldItems, Is.Empty);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_AddsItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(stackSize);
+            var items = this.itemFactory.CreateMany(this.random.Next(1, stackSize));
+            var expectedItems = (T[])items.Clone();
+
+            slot.TryReplace(items, out _);
+
+            Assert.That(slot.GetContents(), Is.EqualTo(expectedItems));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReturnsTrue()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var replacingItems = this.itemFactory.CreateManyRandom(this.random.Next(1, stackSize));
+
+            var result = slot.TryReplace(replacingItems, out _);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_SetsOldItemsToReplacedItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var replacingItems = this.itemFactory.CreateManyRandom(this.random.Next(1, stackSize));
+
+            slot.TryReplace(replacingItems, out var oldItems);
+
+            Assert.That(oldItems, Is.EqualTo(slotItems));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReplacesItems()
+        {
+            var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slotItems = this.itemFactory.CreateMany(stackSize);
+            var slot = this.slotFactory.WithItems(slotItems, stackSize);
+            var replacingItems = this.itemFactory.CreateManyRandom(this.random.Next(1, stackSize));
+            var expectedItems = (T[])replacingItems.Clone();
+
+            slot.TryReplace(replacingItems, out _);
+
+            Assert.That(slot.GetContents(), Is.EqualTo(expectedItems));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide thorough unit test coverage for `InventoryStackSlot<T>.TryReplace` across error, failure and success scenarios to ensure correct return values and `oldItems` semantics.
- Cover edge cases including null input, arrays containing nulls, empty arrays, arrays larger than `MaxAmount`, arrays with differing values, replacing on empty slot, and replacing on non-empty slot.

### Description
- Add new test file `tests/Slots/InventoryStackSlot/InventoryStackSlotTests.try_replace.cs` containing tests that assert exceptions for null inputs and null-containing arrays, false returns for invalid inputs, and true returns for valid replacements.
- Tests verify `oldItems` outputs (null, empty array, or replaced items) and assert final slot contents after successful replacements.
- Tests follow repository conventions by inheriting `BaseTest<T>` and using the provided factories for deterministic randomized scenarios, with no production code changes.

### Testing
- Ran `dotnet test tests/TheChest.Inventories.Tests.csproj --filter "FullyQualifiedName~InventoryStackSlotTests"` and the filtered suite passed (Passed: 104, Failed: 0).
- Ran full test suite with `dotnet test tests/TheChest.Inventories.Tests.csproj` and it passed (Passed: 744, Failed: 0, Skipped: 2).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3974af26e083239cbaf7c739235f12)