### PR TITLE
Add StackInventory.TryReplace unit tests

### DIFF
--- a/tests/Containers/StackInventory/StackInventoryTests.TryReplace.cs
+++ b/tests/Containers/StackInventory/StackInventoryTests.TryReplace.cs
@@ -1,0 +1,284 @@
+using TheChest.Tests.Common.Extensions.Containers;
+
+namespace TheChest.Inventories.Tests.Containers.StackInventory
+{
+    public partial class StackInventoryTests<T>
+    {
+        [Test]
+        public void TryReplace_NullItems_ThrowsArgumentNullException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryReplace(null!, 0, out _),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("items")
+            );
+        }
+
+        [TestCase(-1)]
+        [TestCase(MAX_SIZE_TEST)]
+        public void TryReplace_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var items = this.itemFactory.CreateMany(stackSize);
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryReplace(items, index, out _),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void TryReplace_EmptyItems_ReturnsFalse()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+
+            var result = inventory.TryReplace(Array.Empty<T>(), index, out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_EmptyItems_SetsOldItemsToNull()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+
+            inventory.TryReplace(Array.Empty<T>(), index, out var oldItems);
+
+            Assert.That(oldItems, Is.Null);
+        }
+
+        [Test]
+        public void TryReplace_EmptyItems_DoesNotCallOnReplaceEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var onReplaceCalled = false;
+
+            inventory.OnReplace += (_, _) => onReplaceCalled = true;
+            inventory.TryReplace(Array.Empty<T>(), index, out _);
+
+            Assert.That(onReplaceCalled, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_ItemsContainingNull_ReturnsFalse()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var items = this.itemFactory.CreateMany(stackSize - 1).Append(default).ToArray();
+
+            var result = inventory.TryReplace(items!, index, out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_ItemsContainingNull_DoesNotReplaceItemsInSlot()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var index = this.random.Next(0, size);
+            var items = this.itemFactory.CreateMany(stackSize - 1).Append(default).ToArray();
+
+            inventory.TryReplace(items!, index, out _);
+
+            Assert.That(inventory.GetItems(index), Has.Length.EqualTo(stackSize).And.All.EqualTo(initialItem));
+        }
+
+        [Test]
+        public void TryReplace_ItemsContainingNull_DoesNotCallOnReplaceEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var items = this.itemFactory.CreateMany(stackSize - 1).Append(default).ToArray();
+            var onReplaceCalled = false;
+
+            inventory.OnReplace += (_, _) => onReplaceCalled = true;
+            inventory.TryReplace(items!, index, out _);
+
+            Assert.That(onReplaceCalled, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_MoreItemsThanStackSize_ReturnsFalse()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var items = this.itemFactory.CreateMany(stackSize + 1);
+
+            var result = inventory.TryReplace(items, index, out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_MoreItemsThanStackSize_DoesNotReplaceItemsInSlot()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var index = this.random.Next(0, size);
+            var items = this.itemFactory.CreateMany(stackSize + 1);
+
+            inventory.TryReplace(items, index, out _);
+
+            Assert.That(inventory.GetItems(index), Has.Length.EqualTo(stackSize).And.All.EqualTo(initialItem));
+        }
+
+        [Test]
+        public void TryReplace_MoreItemsThanStackSize_DoesNotCallOnReplaceEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var items = this.itemFactory.CreateMany(stackSize + 1);
+            var onReplaceCalled = false;
+
+            inventory.OnReplace += (_, _) => onReplaceCalled = true;
+            inventory.TryReplace(items, index, out _);
+
+            Assert.That(onReplaceCalled, Is.False);
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReplacesItemsInSlot()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+
+            inventory.TryReplace(newItems, index, out _);
+
+            Assert.That(inventory.GetItems(index), Is.EqualTo(newItems));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_SetsOldItemsToPreviousItems()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+
+            inventory.TryReplace(newItems, index, out var oldItems);
+
+            Assert.That(oldItems, Has.Length.EqualTo(stackSize).And.All.EqualTo(initialItem));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_CallsOnReplaceEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+            var calledWithExpectedData = false;
+
+            inventory.OnReplace += (sender, args) =>
+            {
+                var data = args.Data.Single();
+                calledWithExpectedData =
+                    sender == inventory &&
+                    data.Index == index &&
+                    data.OldItems.Length == stackSize &&
+                    data.OldItems.All(item => item!.Equals(initialItem)) &&
+                    data.NewItems.SequenceEqual(newItems);
+            };
+            inventory.TryReplace(newItems, index, out _);
+
+            Assert.That(calledWithExpectedData, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+
+            var result = inventory.TryReplace(newItems, index, out _);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReplacesItemsInSlot()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+
+            inventory.TryReplace(newItems, index, out _);
+
+            Assert.That(inventory.GetItems(index), Is.EqualTo(newItems));
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsOldItemsToEmptyArray()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+
+            inventory.TryReplace(newItems, index, out var oldItems);
+
+            Assert.That(oldItems, Is.Empty);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_CallsOnReplaceEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+            var calledWithExpectedData = false;
+
+            inventory.OnReplace += (sender, args) =>
+            {
+                var data = args.Data.Single();
+                calledWithExpectedData =
+                    sender == inventory &&
+                    data.Index == index &&
+                    data.OldItems.Length == 0 &&
+                    data.NewItems.SequenceEqual(newItems);
+            };
+            inventory.TryReplace(newItems, index, out _);
+
+            Assert.That(calledWithExpectedData, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+            var newItems = this.itemFactory.CreateManyRandom(stackSize);
+
+            var result = inventory.TryReplace(newItems, index, out _);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve coverage for `StackInventory.TryReplace` by exercising null/invalid inputs, boundary conditions, and event behavior.
- Ensure container-level semantics (old-items output and no-op behavior) are validated for both full and empty slots.

### Description
- Added a new partial test file `tests/Containers/StackInventory/StackInventoryTests.TryReplace.cs` with comprehensive unit tests for `TryReplace` covering null arrays, invalid indices, empty arrays, arrays containing null, arrays larger than stack size, successful replacements on full and empty slots, assertions on `oldItems` outputs, return values, and `OnReplace` event payloads.
- Tests use existing factory helpers and follow the repository testing conventions (inherit `BaseTest<T>`, use randomized deterministic sizes, and check event invocation/state changes).

### Testing
- Ran the focused test filter with `dotnet test tests/TheChest.Inventories.Tests.csproj --no-restore --filter "FullyQualifiedName~StackInventory&Name~TryReplace"` and the added `TryReplace` tests passed (20 passed, 0 failed). 
- Ran the full test suite with `dotnet test tests/TheChest.Inventories.Tests.csproj --no-restore` which failed due to an existing unrelated `TryAddItemAt` test reporting an `ArgumentOutOfRangeException` for `amount`, so the failure is external to these `TryReplace` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3974e22f788323aa642f89a006dda6)