### PR TITLE
Add unit tests for InventoryLazyStackSlot.TryReplace

### DIFF
--- a/tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_replace.cs
+++ b/tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_replace.cs
@@ -1,0 +1,147 @@
+﻿using TheChest.Tests.Common.Extensions.Slots;
+
+namespace TheChest.Inventories.Tests.Slots.InventoryLazyStackSlot
+{
+    public partial class InventoryLazyStackSlotTests<T>
+    {
+        [Test]
+        public void TryReplace_NullItem_ThrowsArgumentNullException()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(maxAmount);
+
+            Assert.That(
+                () => slot.TryReplace(default!, 1, out _),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        [TestCase(MAX_STACK_SIZE_TEST + 1)]
+        public void TryReplace_InvalidAmount_ThrowsArgumentOutOfRangeException(int amount)
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(maxAmount);
+            var item = this.itemFactory.CreateDefault();
+
+            Assert.That(
+                () => slot.TryReplace(item, amount, out _),
+                Throws.Exception.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("amount")
+            );
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsOldItemsToEmptyArray()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(maxAmount);
+            var item = this.itemFactory.CreateDefault();
+            var amount = this.random.Next(1, maxAmount);
+
+            slot.TryReplace(item, amount, out var oldItems);
+
+            Assert.That(oldItems, Is.Empty);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsContent()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(maxAmount);
+            var item = this.itemFactory.CreateDefault();
+            var amount = this.random.Next(1, maxAmount);
+
+            slot.TryReplace(item, amount, out _);
+
+            Assert.That(slot.GetContent(), Is.EqualTo(item));
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsAmount()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(maxAmount);
+            var item = this.itemFactory.CreateDefault();
+            var amount = this.random.Next(1, maxAmount);
+
+            slot.TryReplace(item, amount, out _);
+
+            Assert.That(slot.Amount, Is.EqualTo(amount));
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReturnsTrue()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var slot = this.slotFactory.Empty(maxAmount);
+            var item = this.itemFactory.CreateDefault();
+            var amount = this.random.Next(1, maxAmount);
+
+            var result = slot.TryReplace(item, amount, out _);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_SetsOldItemsToPreviousItems()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var initialItem = this.itemFactory.CreateDefault();
+            var initialAmount = this.random.Next(1, maxAmount);
+            var slot = this.slotFactory.WithItem(initialItem, initialAmount, maxAmount);
+            var item = this.itemFactory.CreateRandom();
+            var amount = this.random.Next(1, maxAmount);
+            var expectedOldItems = Enumerable.Repeat(initialItem, initialAmount).ToArray();
+
+            slot.TryReplace(item, amount, out var oldItems);
+
+            Assert.That(oldItems, Is.EqualTo(expectedOldItems));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReplacesContent()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var initialItem = this.itemFactory.CreateDefault();
+            var initialAmount = this.random.Next(1, maxAmount);
+            var slot = this.slotFactory.WithItem(initialItem, initialAmount, maxAmount);
+            var item = this.itemFactory.CreateRandom();
+            var amount = this.random.Next(1, maxAmount);
+
+            slot.TryReplace(item, amount, out _);
+
+            Assert.That(slot.GetContent(), Is.EqualTo(item));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReplacesAmount()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var initialItem = this.itemFactory.CreateDefault();
+            var initialAmount = this.random.Next(1, maxAmount);
+            var slot = this.slotFactory.WithItem(initialItem, initialAmount, maxAmount);
+            var item = this.itemFactory.CreateRandom();
+            var amount = this.random.Next(1, maxAmount);
+
+            slot.TryReplace(item, amount, out _);
+
+            Assert.That(slot.Amount, Is.EqualTo(amount));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReturnsTrue()
+        {
+            var maxAmount = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
+            var initialItem = this.itemFactory.CreateDefault();
+            var initialAmount = this.random.Next(1, maxAmount);
+            var slot = this.slotFactory.WithItem(initialItem, initialAmount, maxAmount);
+            var item = this.itemFactory.CreateRandom();
+            var amount = this.random.Next(1, maxAmount);
+
+            var result = slot.TryReplace(item, amount, out _);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure `TryReplace` on `InventoryLazyStackSlot` validates inputs and reports parameter names for invalid `item` and `amount` values.
- Verify `TryReplace` correctly returns previous contents via `oldItems` for both empty and populated slots.
- Confirm `TryReplace` updates slot `Content` and `Amount` and returns the expected boolean result.

### Description

- Added a new test file `tests/Slots/InventoryLazyStackSlot/InventoryLazyStackSlotTests.try_replace.cs` containing comprehensive unit tests for `TryReplace`.
- Added tests that assert `TryReplace(default!, ...)` throws `ArgumentNullException` with `ParamName == "item"` and that invalid `amount` values throw `ArgumentOutOfRangeException` with `ParamName == "amount"`.
- Added tests to verify behavior when replacing on an empty slot: `oldItems` is empty, slot `Content` and `Amount` are set, and the method returns `true`.
- Added tests to verify behavior when replacing a populated slot: `oldItems` contains the previous items, the slot `Content` and `Amount` are replaced, and the method returns `true`.

### Testing

- Ran the unit test suite including the new `InventoryLazyStackSlot.TryReplace` tests using the project's test runner; the new tests executed successfully.
- All automated tests, including the added test file, passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8b4f17b08323a7fcf8f9805363ef)