### PR TITLE
Fix TryReplace index bounds and event handling; add unit tests

### DIFF
--- a/src/Containers/LazyStackInventory.Replace.cs
+++ b/src/Containers/LazyStackInventory.Replace.cs
@@ -60,9 +60,9 @@ namespace TheChest.Inventories.Containers
                 throw new ArgumentOutOfRangeException(nameof(index));
 
             var replaced = this.slots[index].TryReplace(item, amount, out oldItems);
-            if (replaced && oldItems.Length > 0)
+            if (replaced)
                 this.OnReplace?.Invoke(this, (oldItems[0], oldItems.Length, item, amount, index));
-            else if (replaced)
+            else
                 this.OnReplace?.Invoke(this, (default, 0, item, amount, index));
 
             return replaced;

--- a/src/Containers/LazyStackInventory.Replace.cs
+++ b/src/Containers/LazyStackInventory.Replace.cs
@@ -56,12 +56,14 @@ namespace TheChest.Inventories.Containers
                 throw new ArgumentNullException(nameof(item));
             if (amount <= 0)
                 throw new ArgumentOutOfRangeException(nameof(amount));
-            if (index < 0 || index > this.Size)
+            if (index < 0 || index >= this.Size)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
             var replaced = this.slots[index].TryReplace(item, amount, out oldItems);
-            if (replaced)
+            if (replaced && oldItems.Length > 0)
                 this.OnReplace?.Invoke(this, (oldItems[0], oldItems.Length, item, amount, index));
+            else if (replaced)
+                this.OnReplace?.Invoke(this, (default, 0, item, amount, index));
 
             return replaced;
         }

--- a/tests/Containers/LazyStackInventory/LazyStackInventoryTests.TryReplace.cs
+++ b/tests/Containers/LazyStackInventory/LazyStackInventoryTests.TryReplace.cs
@@ -1,0 +1,215 @@
+﻿using TheChest.Tests.Common.Extensions.Containers;
+
+namespace TheChest.Inventories.Tests.Containers.LazyStackInventory
+{
+    public partial class LazyStackInventoryTests<T>
+    {
+        [Test]
+        public void TryReplace_NullItem_ThrowsArgumentNullException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryReplace(default!, 0, 1, out _),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("item")
+            );
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void TryReplace_InvalidAmount_ThrowsArgumentOutOfRangeException(int amount)
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+
+            Assert.That(
+                () => inventory.TryReplace(item, index, amount, out _),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("amount")
+            );
+        }
+
+        [TestCase(-1)]
+        [TestCase(MAX_SIZE_TEST)]
+        public void TryReplace_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryReplace(item, index, 1, out _),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void TryReplace_IndexEqualToSize_ThrowsArgumentOutOfRangeException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+
+            Assert.That(
+                () => inventory.TryReplace(item, size, 1, out _),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("index")
+            );
+        }
+
+        [Test]
+        public void TryReplace_MoreItemsThanStackSize_ThrowsArgumentOutOfRangeException()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var item = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var index = this.random.Next(0, size);
+
+            Assert.That(
+                () => inventory.TryReplace(item, index, stackSize + 1, out _),
+                Throws.TypeOf<ArgumentOutOfRangeException>().With.Property("ParamName").EqualTo("amount")
+            );
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReplacesItemsInSlot()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var newItem = this.itemFactory.CreateRandom();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+
+            inventory.TryReplace(newItem, index, amount, out _);
+
+            Assert.That(inventory.GetItems(index), Has.Length.EqualTo(amount).And.All.EqualTo(newItem));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_SetsOldItemsToPreviousItems()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var newItem = this.itemFactory.CreateRandom();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+
+            inventory.TryReplace(newItem, index, amount, out var oldItems);
+
+            Assert.That(oldItems, Has.Length.EqualTo(stackSize).And.All.EqualTo(initialItem));
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_CallsOnReplaceEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var newItem = this.itemFactory.CreateRandom();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+            var calledWithExpectedData = false;
+
+            inventory.OnReplace += (sender, args) =>
+            {
+                var data = args.Data.Single();
+                calledWithExpectedData =
+                    sender == inventory &&
+                    data.Index == index &&
+                    data.OldItem!.Equals(initialItem) &&
+                    data.OldAmount == stackSize &&
+                    data.NewItem!.Equals(newItem) &&
+                    data.NewAmount == amount;
+            };
+            inventory.TryReplace(newItem, index, amount, out _);
+
+            Assert.That(calledWithExpectedData, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_SlotWithItems_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var initialItem = this.itemFactory.CreateDefault();
+            var inventory = this.inventoryFactory.FullContainer(size, stackSize, initialItem);
+            var newItem = this.itemFactory.CreateRandom();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+
+            var result = inventory.TryReplace(newItem, index, amount, out _);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReplacesItemsInSlot()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var newItem = this.itemFactory.CreateDefault();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+
+            inventory.TryReplace(newItem, index, amount, out _);
+
+            Assert.That(inventory.GetItems(index), Has.Length.EqualTo(amount).And.All.EqualTo(newItem));
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_SetsOldItemsToEmptyArray()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var newItem = this.itemFactory.CreateDefault();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+
+            inventory.TryReplace(newItem, index, amount, out var oldItems);
+
+            Assert.That(oldItems, Is.Empty);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_CallsOnReplaceEvent()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var newItem = this.itemFactory.CreateDefault();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+            var calledWithExpectedData = false;
+
+            inventory.OnReplace += (sender, args) =>
+            {
+                var data = args.Data.Single();
+                calledWithExpectedData =
+                    sender == inventory &&
+                    data.Index == index &&
+                    data.OldItem == null &&
+                    data.OldAmount == 0 &&
+                    data.NewItem!.Equals(newItem) &&
+                    data.NewAmount == amount;
+            };
+            inventory.TryReplace(newItem, index, amount, out _);
+
+            Assert.That(calledWithExpectedData, Is.True);
+        }
+
+        [Test]
+        public void TryReplace_EmptySlot_ReturnsTrue()
+        {
+            var (size, stackSize) = this.GenerateRandomSizeAndStackSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size, stackSize);
+            var newItem = this.itemFactory.CreateDefault();
+            var index = this.random.Next(0, size);
+            var amount = this.random.Next(1, stackSize + 1);
+
+            var result = inventory.TryReplace(newItem, index, amount, out _);
+
+            Assert.That(result, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure `TryReplace` enforces correct index bounds and does not access `this.slots` with `index == Size`.
- Make `OnReplace` event payload consistent when replacing into an empty slot so callers receive a clear empty/zero old-item representation.

### Description

- Changed the index validation in `LazyStackInventory.Replace.cs` from `if (index < 0 || index > this.Size)` to `if (index < 0 || index >= this.Size)` to reject `index == Size`.
- Updated `TryReplace` event invocation to only read `oldItems[0]` when `oldItems.Length > 0` and to invoke `OnReplace` with `(default, 0, ...)` when the replacement succeeded but there were no old items.
- Added comprehensive unit tests in `tests/Containers/LazyStackInventory/LazyStackInventoryTests.TryReplace.cs` covering argument validation, behavior for empty and populated slots, event payloads, and return values for `TryReplace`.

### Testing

- Added a new test file `LazyStackInventoryTests.TryReplace.cs` exercising `TryReplace` edge cases and normal behaviors.
- Ran the automated unit test suite with the new tests (e.g. `dotnet test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a89a01d9483238e5313059f97d824)