### PR TITLE
Improve Inventory move tests for value types

### DIFF
--- a/tests/Containers/Inventory/InventoryTests.CanMove.cs
+++ b/tests/Containers/Inventory/InventoryTests.CanMove.cs
@@ -1,4 +1,6 @@
-﻿namespace TheChest.Inventories.Tests.Containers.Inventory
+﻿using TheChest.Tests.Common.Attributes;
+
+namespace TheChest.Inventories.Tests.Containers.Inventory
 {
     public partial class InventoryTests<T>
     {
@@ -92,6 +94,21 @@
             var inventory = this.inventoryFactory.EmptyContainer(size);
 
             var item = this.itemFactory.CreateRandom();
+            inventory.Add(item);
+
+            var canMove = inventory.CanMove(0, 1);
+
+            Assert.That(canMove, Is.True);
+        }
+
+
+        [Test]
+        [IgnoreIfReferenceType]
+        public void CanMove_DefaultValueItemToEmptyTarget_ReturnsTrue()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var item = default(T);
             inventory.Add(item);
 
             var canMove = inventory.CanMove(0, 1);

--- a/tests/Containers/Inventory/InventoryTests.Move.cs
+++ b/tests/Containers/Inventory/InventoryTests.Move.cs
@@ -1,4 +1,5 @@
-﻿using TheChest.Tests.Common.Extensions.Containers;
+﻿using TheChest.Tests.Common.Attributes;
+using TheChest.Tests.Common.Extensions.Containers;
 
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
@@ -83,18 +84,17 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         public void Move_BothSlotsWithItems_SwapsItems()
         {
             var size = this.GenerateRandomSize();
-            var items = this.itemFactory.CreateManyRandom(size);
-            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, items);
-
+            var inventory = this.inventoryFactory.EmptyContainer(size);
             var origin = 0;
             var target = 1;
-            var itemFromOrigin = inventory.GetItem(origin);
-            var ItemFromTarget = inventory.GetItem(target);
+            var (itemFromOrigin, itemFromTarget) = this.CreateDistinctItems();
+            inventory.AddAt(itemFromOrigin, origin);
+            inventory.AddAt(itemFromTarget, target);
             inventory.Move(origin, target);
 
             Assert.Multiple(() =>
             {
-                Assert.That(inventory.GetItem(origin), Is.EqualTo(ItemFromTarget));
+                Assert.That(inventory.GetItem(origin), Is.EqualTo(itemFromTarget));
                 Assert.That(inventory.GetItem(target), Is.EqualTo(itemFromOrigin));
             });
         }
@@ -103,13 +103,12 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         public void Move_BothSlotsWithItems_CallsOnMoveWithTwoMovedItems()
         {
             var size = this.GenerateRandomSize();
-            var items = this.itemFactory.CreateManyRandom(size);
-            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, items);
-
+            var inventory = this.inventoryFactory.EmptyContainer(size);
             var origin = 0;
             var target = 1;
-            var itemFromOrigin = inventory.GetItem(origin);
-            var ItemFromTarget = inventory.GetItem(target);
+            var (itemFromOrigin, itemFromTarget) = this.CreateDistinctItems();
+            inventory.AddAt(itemFromOrigin, origin);
+            inventory.AddAt(itemFromTarget, target);
 
             var raised = false;
             inventory.OnMove += (sender, args) =>
@@ -126,7 +125,7 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
 
                 Assert.Multiple(() =>
                 {
-                    Assert.That(dataArray[1].Item, Is.EqualTo(ItemFromTarget));
+                    Assert.That(dataArray[1].Item, Is.EqualTo(itemFromTarget));
                     Assert.That(dataArray[1].FromIndex, Is.EqualTo(1));
                     Assert.That(dataArray[1].ToIndex, Is.EqualTo(0));
                 });
@@ -183,6 +182,25 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
             inventory.Move(0, 1);
 
             Assert.That(raised, Is.True, "OnMove event was not raised");
+        }
+
+
+        [Test]
+        [IgnoreIfReferenceType]
+        public void Move_DefaultValueItemToEmptyTarget_MovesItem()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var item = default(T);
+            inventory.Add(item);
+
+            inventory.Move(0, 1);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(inventory.GetSlot(0).IsEmpty, Is.True);
+                Assert.That(inventory.GetItem(1), Is.EqualTo(item));
+            });
         }
 
         [Test]

--- a/tests/Containers/Inventory/InventoryTests.TryMove.cs
+++ b/tests/Containers/Inventory/InventoryTests.TryMove.cs
@@ -1,4 +1,5 @@
-﻿using TheChest.Tests.Common.Extensions.Containers;
+﻿using TheChest.Tests.Common.Attributes;
+using TheChest.Tests.Common.Extensions.Containers;
 
 namespace TheChest.Inventories.Tests.Containers.Inventory
 {
@@ -99,12 +100,12 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         public void TryMove_BothSlotsWithItems_SwapsItems()
         {
             var size = this.GenerateRandomSize();
-            var items = this.itemFactory.CreateManyRandom(size);
-            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, items);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
             var origin = 0;
             var target = 1;
-            var itemFromOrigin = inventory.GetItem(origin);
-            var itemFromTarget = inventory.GetItem(target);
+            var (itemFromOrigin, itemFromTarget) = this.CreateDistinctItems();
+            inventory.AddAt(itemFromOrigin, origin);
+            inventory.AddAt(itemFromTarget, target);
 
             inventory.TryMove(origin, target);
 
@@ -119,12 +120,12 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
         public void TryMove_BothSlotsWithItems_CallsOnMoveWithTwoMovedItems()
         {
             var size = this.GenerateRandomSize();
-            var items = this.itemFactory.CreateManyRandom(size);
-            var inventory = this.inventoryFactory.ShuffledItemsContainer(size, items);
+            var inventory = this.inventoryFactory.EmptyContainer(size);
             var origin = 0;
             var target = 1;
-            var itemFromOrigin = inventory.GetItem(origin);
-            var itemFromTarget = inventory.GetItem(target);
+            var (itemFromOrigin, itemFromTarget) = this.CreateDistinctItems();
+            inventory.AddAt(itemFromOrigin, origin);
+            inventory.AddAt(itemFromTarget, target);
             var raised = false;
             inventory.OnMove += (sender, args) =>
             {
@@ -193,6 +194,25 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
             inventory.TryMove(0, 1);
 
             Assert.That(raised, Is.True);
+        }
+
+
+        [Test]
+        [IgnoreIfReferenceType]
+        public void TryMove_DefaultValueItemToEmptyTarget_MovesItem()
+        {
+            var size = this.GenerateRandomSize();
+            var inventory = this.inventoryFactory.EmptyContainer(size);
+            var item = default(T);
+            inventory.Add(item);
+
+            inventory.TryMove(0, 1);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(inventory.GetSlot(0).IsEmpty, Is.True);
+                Assert.That(inventory.GetItem(1), Is.EqualTo(item));
+            });
         }
 
         [Test]

--- a/tests/Containers/Inventory/InventoryTests.cs
+++ b/tests/Containers/Inventory/InventoryTests.cs
@@ -1,4 +1,6 @@
-﻿using TheChest.Inventories.Containers;
+﻿using System;
+using System.Linq;
+using TheChest.Inventories.Containers;
 using TheChest.Inventories.Slots;
 using TheChest.Inventories.Tests.Containers.Factories;
 using TheChest.Inventories.Tests.Containers.Interfaces;
@@ -21,5 +23,25 @@ namespace TheChest.Inventories.Tests.Containers.Inventory
                 .Register<IInventorySlotFactory<T>, InventorySlotFactory<InventorySlot<T>, T>>()
                 .Register<IInventoryFactory<T>, InventoryFactory<Inventory<T>, T>>();
         }) { }
+
+        protected (T First, T Second) CreateDistinctItems()
+        {
+            if (typeof(T).IsEnum)
+            {
+                var values = Enum.GetValues(typeof(T)).Cast<T>().Skip(1).Take(2).ToArray();
+                if (values.Length >= 2)
+                    return (values[0], values[1]);
+            }
+
+            var first = this.itemFactory.CreateRandom();
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                var second = this.itemFactory.CreateRandom();
+                if (!object.Equals(first, second))
+                    return (first, second);
+            }
+
+            throw new InvalidOperationException($"Could not create distinct items for {typeof(T).FullName}.");
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure `Move`, `TryMove`, and `CanMove` unit tests behave correctly for value-type item parameters (including enums) where default/equality can break assertions.
- Make swap/event assertions deterministic by using distinct arranged items instead of relying on shuffled factory output that may produce duplicate values for value-types.

### Description

- Add a shared helper `CreateDistinctItems()` in `tests/Containers/Inventory/InventoryTests.cs` to produce two distinct generic test items and return deterministic enum pairs when applicable.
- Replace shuffled/factory-based arrangements in `Move` and `TryMove` tests with explicit arrangements that `AddAt` two distinct items to origin and target slots so swap and event assertions work for value-types.
- Add value-type-specific tests marked with `[IgnoreIfReferenceType]` to cover moving `default(T)` into an empty target for `Move`, `TryMove`, and `CanMove`.
- Add `using TheChest.Tests.Common.Attributes;` (and required `System`/`System.Linq` imports) to test files to support the new attribute usage.

### Testing

- Ran `git diff --check` to validate formatting and found no issues (passed).
- Attempted to run `dotnet test --filter "FullyQualifiedName~TheChest.Inventories.Tests.Containers.Inventory.InventoryTests"` but the build/test run was blocked by NuGet restore failures (`NU1301` unable to reach https://api.nuget.org/v3/index.json), so tests could not be executed in this environment (failed due to external restore error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67863337c88323a120335637760616)