### PR TITLE
Rename InventoryStackSlot tests to follow repository test-naming convention

### DIFF
--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_item.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_item.cs
@@ -7,7 +7,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     {
         [Test]
         [IgnoreIfValueType]
-        public void Add_NullItem_ThrowsNullArgumentException()
+        public void Add_NullItem_ThrowsArgumentNullException()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -19,7 +19,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Add_Full_ThrowsInvalidOperationException()
+        public void Add_FullSlot_ThrowsInvalidOperationException()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateMany(stackSize);
@@ -33,7 +33,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Add_ContainingDifferentItem_ThrowsInvalidOperationException()
+        public void Add_SlotWithDifferentItem_ThrowsInvalidOperationException()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStackSize = stackSize / 2;
@@ -48,7 +48,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Add_Empty_AddsToContent()
+        public void Add_EmptySlot_AddsItem()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -60,7 +60,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Add_Empty_IncreasesAmount()
+        public void Add_EmptySlot_IncreasesAmount()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -73,7 +73,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Add_Empty_DefaultValue_AddsToContent()
+        public void Add_EmptySlot_DefaultValueItem_AddsItem()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -86,7 +86,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Add_Empty_DefaultValue_IncreasesAmount()
+        public void Add_EmptySlot_DefaultValueItem_IncreasesAmount()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -98,7 +98,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Add_ContainingSameItem_AddsToContent()
+        public void Add_SlotWithSameItem_AddsItem()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStackSize = stackSize / 2;

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_items.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.add_items.cs
@@ -8,7 +8,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     {
         #region Param Validation Tests
         [Test]
-        public void AddItems_EmptyArray_ThrowsArgumentException()
+        public void AddItems_EmptyItems_ThrowsArgumentException()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -23,7 +23,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfValueType]
-        public void AddItems_ArrayContainingNull_ThrowsArgumentNullException()
+        public void AddItems_ItemsContainingNull_ThrowsArgumentNullException()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -41,7 +41,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_ArrayContainingDifferentItems_ThrowsArgumentException()
+        public void AddItems_ItemsContainingDifferentValues_ThrowsArgumentException()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -77,7 +77,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_MoreItemsThanMaxAmount_ThrowsInvalidOperationException()
+        public void AddItems_EmptySlot_ItemsExceedingMaxAmount_ThrowsInvalidOperationException()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -92,7 +92,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_MoreThanAvailableAmount_ThrowsInvalidOperationException()
+        public void AddItems_SlotWithLimitedSpace_ItemsExceedingAvailableAmount_ThrowsInvalidOperationException()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStackSize = stackSize / 2;
@@ -109,7 +109,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_DifferentItemsFromSlot_ThrowsInvalidOperationException()
+        public void AddItems_SlotWithDifferentItems_ThrowsInvalidOperationException()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStackSize = stackSize / 2;
@@ -141,7 +141,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_EmptySlot_AddsToContent()
+        public void AddItems_EmptySlot_AddsItems()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -155,7 +155,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_SlotContainingSameItems_IncreasesAmount()
+        public void AddItems_SlotWithSameItems_IncreasesAmount()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStackSize = stackSize / 2;
@@ -171,7 +171,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AddItems_SlotContainingSameItems_AddsToContent()
+        public void AddItems_SlotWithSameItems_AddsItems()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStackSize = stackSize / 2;

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.available_amount.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.available_amount.cs
@@ -5,7 +5,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     public partial class InventoryStackSlotTests<T>
     {
         [Test]
-        public void AvailableAmount_Empty_ReturnsMaxStackAmount()
+        public void AvailableAmount_EmptySlot_ReturnsMaxAmount()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -15,7 +15,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void AvailableAmount_PartiallyFilled_ValueType_ReturnsMaxStackAmountMinusAmount()
+        public void AvailableAmount_PartiallyFilledSlot_ValueType_ReturnsAvailableSpace()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var amount = this.random.Next(1, stackSize);
@@ -25,7 +25,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AvailableAmount_PartiallyFilled_ReturnsMaxStackAmountMinusAmount()
+        public void AvailableAmount_PartiallyFilledSlot_ReturnsAvailableSpace()
         {
             var item = this.itemFactory.CreateRandom();
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
@@ -36,7 +36,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void AvailableAmount_Full_ReturnsZero()
+        public void AvailableAmount_FullSlot_ReturnsZero()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -47,7 +47,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void AvailableAmount_Full_ValueType_ReturnsZero()
+        public void AvailableAmount_FullSlot_ValueType_ReturnsZero()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = Enumerable.Repeat(default(T), stackSize).ToArray();
@@ -58,7 +58,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfValueType]
-        public void AvailableAmount_Full_ReferenceType_ReturnsMaxAmount()
+        public void AvailableAmount_FullSlot_ReferenceType_ReturnsMaxAmount()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = Enumerable.Repeat(default(T), stackSize).ToArray();

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.can_add_item.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.can_add_item.cs
@@ -18,7 +18,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void CanAddItem_DefaultItem_ReturnsTrue()
+        public void CanAddItem_DefaultValueItem_ReturnsTrue()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -29,7 +29,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void CanAddItem_Empty_ReturnsTrue()
+        public void CanAddItem_EmptySlot_ReturnsTrue()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -41,7 +41,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void CanAddItem_AvailableSpace_DifferentItem_ReturnsFalse()
+        public void CanAddItem_SlotWithAvailableSpace_DifferentItem_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var itemsAmount = this.random.Next(1, stackSize - 1);
@@ -55,7 +55,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void CanAddItem_AvailableSpace_SameItem_ReturnsTrue()
+        public void CanAddItem_SlotWithAvailableSpace_SameItem_ReturnsTrue()
         {
             var stackSize = this.GetRandomStackSize();
             var itemsAmount = this.random.Next(1, stackSize - 1);
@@ -69,7 +69,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void CanAddItem_Full_ReturnsFalse()
+        public void CanAddItem_FullSlot_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateMany(stackSize);

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.can_add_items.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.can_add_items.cs
@@ -3,7 +3,7 @@
     public partial class InventoryStackSlotTests<T>
     {
         [Test]
-        public void CanAddItems_NullArray_ReturnsFalse()
+        public void CanAddItems_NullItems_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -14,7 +14,7 @@
         }
 
         [Test]
-        public void CanAddItems_EmptyArray_ReturnsFalse()
+        public void CanAddItems_EmptyItems_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -25,7 +25,7 @@
         }
 
         [Test]
-        public void CanAddItems_Empty_ReturnsTrue()
+        public void CanAddItems_EmptySlot_ReturnsTrue()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -37,7 +37,7 @@
         }
 
         [Test]
-        public void CanAddItems_Full_ReturnsFalse()
+        public void CanAddItems_FullSlot_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateMany(stackSize);
@@ -50,7 +50,7 @@
         }
 
         [Test]
-        public void CanAddItems_DifferentItems_ReturnsFalse()
+        public void CanAddItems_ItemsWithDifferentValues_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -65,7 +65,7 @@
         }
 
         [Test]
-        public void CanAddItems_NoAvailableSpace_ReturnsFalse()
+        public void CanAddItems_SlotWithoutAvailableSpace_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateMany(stackSize);
@@ -78,7 +78,7 @@
         }
 
         [Test]
-        public void CanAddItems_AvailableSpace_ReturnsTrue()
+        public void CanAddItems_SlotWithAvailableSpace_ReturnsTrue()
         {
             var stackSize = this.GetRandomStackSize();
             var itemsSize = stackSize / 2;
@@ -93,7 +93,7 @@
         }
 
         [Test]
-        public void CanAddItems_EqualItems_ReturnsTrue()
+        public void CanAddItems_SlotWithSameItems_ReturnsTrue()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStackSize = stackSize / 2;

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.get.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.get.cs
@@ -6,7 +6,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     public partial class InventoryStackSlotTests<T>
     {
         [Test]
-        public void Get_Empty_ThrowsInvalidOperationException()
+        public void Get_EmptySlot_ThrowsInvalidOperationException()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -19,7 +19,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Get_Full_ValueType_ReturnsItem()
+        public void Get_FullSlot_ValueType_ReturnsItem()
         {
             var stackSize = this.GetRandomStackSize();
             var items = Enumerable.Repeat(default(T), stackSize).ToArray();
@@ -31,7 +31,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Get_Full_ReturnsItem()
+        public void Get_FullSlot_ReturnsItem()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -43,7 +43,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Get_Full_DecreasesAmountByOne()
+        public void Get_FullSlot_DecreasesAmountByOne()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateMany(stackSize);
@@ -55,7 +55,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Get_Full_RemovesOneItemFromSlot()
+        public void Get_FullSlot_RemovesItem()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateMany(stackSize);

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.get_all.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.get_all.cs
@@ -5,7 +5,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     public partial class InventoryStackSlotTests<T>
     {
         [Test]
-        public void GetAll_Empty_ReturnsEmptyArray()
+        public void GetAll_EmptySlot_ReturnsEmptyArray()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -16,7 +16,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAll_Full_RemovesAllContents()
+        public void GetAll_FullSlot_RemovesAllItems()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -28,7 +28,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAll_Full_DecreasesAmountToZero()
+        public void GetAll_FullSlot_DecreasesAmountToZero()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -40,7 +40,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAll_Full_ReturnsAllItems()
+        public void GetAll_FullSlot_ReturnsAllItems()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -52,7 +52,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAll_PartiallyFilled_ReturnsAllItems()
+        public void GetAll_PartiallyFilledSlot_ReturnsAllItems()
         {
             var stackSize = this.GetRandomStackSize();
             var amount = this.random.Next(1, stackSize - 1);

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.get_amount.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.get_amount.cs
@@ -7,7 +7,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     {
         [TestCase(0)]
         [TestCase(-1)]
-        public void GetAmount_InvalidAmount_ThrowsArgumentExceptions(int amount)
+        public void GetAmount_InvalidAmount_ThrowsArgumentException(int amount)
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateMany(stackSize);
@@ -20,7 +20,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_Empty_ReturnsEmptyArray()
+        public void GetAmount_EmptySlot_ReturnsEmptyArray()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -33,7 +33,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void GetAmount_Full_ValueType_ReturnsEmptyArray()
+        public void GetAmount_FullSlot_ValueType_ReturnsEmptyArray()
         {
             var stackSize = this.GetRandomStackSize();
             var items = Enumerable.Repeat(default(T), stackSize).ToArray();
@@ -47,7 +47,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void GetAmount_Full_ValueType_DecreasesAmount()
+        public void GetAmount_FullSlot_ValueType_DecreasesAmount()
         {
             var stackSize = this.GetRandomStackSize();
             var items = Enumerable.Repeat(default(T), stackSize).ToArray();
@@ -61,7 +61,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void GetAmount_Full_ValueType_RemovesAmountFromContent()
+        public void GetAmount_FullSlot_ValueType_RemovesItems()
         {
             var stackSize = this.GetRandomStackSize();
             var items = Enumerable.Repeat(default(T), stackSize).ToArray();
@@ -74,7 +74,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_EnoughItems_DecreasesAmount()
+        public void GetAmount_SlotWithEnoughItems_DecreasesAmount()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -87,7 +87,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_EnoughItems_RemovesAmountFromContent()
+        public void GetAmount_SlotWithEnoughItems_RemovesItems()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -100,7 +100,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_EnoughItems_ReturnsItems()
+        public void GetAmount_SlotWithEnoughItems_ReturnsItems()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -113,7 +113,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_NotEnoughItems_ReturnsItems()
+        public void GetAmount_SlotWithoutEnoughItems_ReturnsAllItems()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStack = stackSize / 2;
@@ -127,7 +127,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_NotEnoughItems_RemovesAmountFromContent()
+        public void GetAmount_SlotWithoutEnoughItems_RemovesAllItems()
         {
             var stackSize = this.GetRandomStackSize();
             var halfStack = stackSize / 2;
@@ -141,7 +141,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_AmountBiggerThanAvailable_ReturnsAllItems()
+        public void GetAmount_AmountExceedingAvailable_ReturnsAllItems()
         {
             var stackSize = this.GetRandomStackSize();
             var items = this.itemFactory.CreateManyRandom(stackSize);
@@ -153,7 +153,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void GetAmount_AmountBiggerThanAvailable_DecreasesAmountToZero()
+        public void GetAmount_AmountExceedingAvailable_DecreasesAmountToZero()
         {
             var stackSize = this.GetRandomStackSize();
             var itemSize = this.random.Next(1, stackSize / 2);

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.replace.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.replace.cs
@@ -5,7 +5,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     public partial class InventoryStackSlotTests<T>
     {
         [Test]
-        public void Replace_EmptyItemReplace_ThrowsArgumentException()
+        public void ReplaceItems_EmptyItems_ThrowsArgumentException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slotItems = this.itemFactory.CreateMany(stackSize);
@@ -16,7 +16,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Replace_ItemsBiggerThanMaxAmount_ThrowsArgumentOutOfRangeException()
+        public void ReplaceItems_ItemsExceedingMaxAmount_ThrowsArgumentOutOfRangeException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -26,7 +26,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Replace_EmptySlot_AddsItem()
+        public void ReplaceItems_EmptySlot_ReplacesItems()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -39,7 +39,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Replace_ItemsDifferentFromSlot_AddsItemsToSlot()
+        public void ReplaceItems_SlotWithDifferentItems_ReplacesItems()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = this.itemFactory.CreateMany(stackSize);
@@ -54,7 +54,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void Replace_ItemsEqualToSlot_AddsItemsToSlot()
+        public void ReplaceItems_SlotWithSameItems_ReplacesItems()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var halfStackSize = stackSize / 2;

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.replace_one.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.replace_one.cs
@@ -7,7 +7,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
     {
         [Test]
         [IgnoreIfValueType]
-        public void ReplaceOne_NullItemReplace_ThrowsArgumentNullException()
+        public void ReplaceItem_NullItem_ThrowsArgumentNullException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slotItems = this.itemFactory.CreateMany(stackSize);
@@ -17,7 +17,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void ReplaceOne_EmptySlot_AddsItem()
+        public void ReplaceItem_EmptySlot_ReplacesItem()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -32,7 +32,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void ReplaceOne_ItemDifferentFromSlot_AddsItemsToSlot()
+        public void ReplaceItem_SlotWithDifferentItem_ReplacesItem()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = this.itemFactory.CreateMany(stackSize);
@@ -48,7 +48,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void ReplaceOne_ItemEqualToSlot_AddsItemsToSlot()
+        public void ReplaceItem_SlotWithSameItem_ReplacesItem()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var items = this.itemFactory.CreateMany(stackSize / 2);

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.try_add.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.try_add.cs
@@ -19,7 +19,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfValueType]
-        public void TryAdd_ArrayContainingNull_ThrowsArgumentNullException()
+        public void TryAdd_ItemsContainingNull_ThrowsArgumentNullException()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -46,7 +46,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryAdd_FullSlot_DoesNotAddItems()
+        public void TryAdd_FullSlot_DoesntAddItems()
         {
             var stackSize = this.GetRandomStackSize();
             var slotItems = this.itemFactory.CreateMany(stackSize);
@@ -60,7 +60,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryAdd_NotEnoughCapacity_ReturnsFalse()
+        public void TryAdd_SlotWithLimitedSpace_ReturnsFalse()
         {
             var stackSize = this.GetRandomStackSize();
             var currentAmount = this.random.Next(1, stackSize - 1);
@@ -75,7 +75,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryAdd_NotEnoughCapacity_DoesNotAddItems()
+        public void TryAdd_SlotWithLimitedSpace_DoesntAddItems()
         {
             var stackSize = this.GetRandomStackSize();
             var currentAmount = this.random.Next(1, stackSize - 1);
@@ -91,7 +91,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryAdd_ArrayContainingDefault_AddsToContent()
+        public void TryAdd_EmptySlot_ItemsContainingDefault_AddsItems()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -104,7 +104,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryAdd_ArrayContainingDefault_IncreasesAmount()
+        public void TryAdd_EmptySlot_ItemsContainingDefault_IncreasesAmount()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -117,7 +117,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryAdd_ArrayContainingDefault_ReturnsTrue()
+        public void TryAdd_EmptySlot_ItemsContainingDefault_ReturnsTrue()
         {
             var stackSize = this.GetRandomStackSize();
             var slot = this.slotFactory.Empty(stackSize);
@@ -129,7 +129,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryAdd_SlotWithDifferentItems_DoesNotAddItems()
+        public void TryAdd_SlotWithDifferentItems_DoesntAddItems()
         {
             var stackSize = this.GetRandomStackSize();
             var currentAmount = this.random.Next(1, stackSize - 1);
@@ -159,7 +159,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryAdd_ValidItems_ReturnsTrue()
+        public void TryAdd_SlotWithAvailableSpace_ValidItems_ReturnsTrue()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var currentAmount = this.random.Next(1, stackSize - 1);

--- a/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.try_replace.cs
+++ b/tests/Slots/InventoryStackSlot/InventoryStackSlotTests.try_replace.cs
@@ -17,7 +17,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
 
         [Test]
         [IgnoreIfValueType]
-        public void TryReplace_ArrayContainingNull_ThrowsArgumentNullException()
+        public void TryReplace_ItemsContainingNull_ThrowsArgumentNullException()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -53,7 +53,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryReplace_EmptyItems_DoesNotReplaceItems()
+        public void TryReplace_EmptyItems_DoesntReplaceItems()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slotItems = this.itemFactory.CreateMany(stackSize);
@@ -66,7 +66,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryReplace_ItemsBiggerThanMaxAmount_ReturnsFalse()
+        public void TryReplace_ItemsExceedingMaxAmount_ReturnsFalse()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -78,7 +78,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryReplace_ItemsBiggerThanMaxAmount_SetsOldItemsToNull()
+        public void TryReplace_ItemsExceedingMaxAmount_SetsOldItemsToNull()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -90,7 +90,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryReplace_ItemsWithDifferentValues_ReturnsFalse()
+        public void TryReplace_ItemsContainingDifferentValues_ReturnsFalse()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);
@@ -126,7 +126,7 @@ namespace TheChest.Inventories.Tests.Slots.InventoryStackSlot
         }
 
         [Test]
-        public void TryReplace_EmptySlot_AddsItems()
+        public void TryReplace_EmptySlot_ReplacesItems()
         {
             var stackSize = this.random.Next(MIN_STACK_SIZE_TEST, MAX_STACK_SIZE_TEST);
             var slot = this.slotFactory.Empty(stackSize);


### PR DESCRIPTION
### Motivation
- Bring all unit test names under `tests/Slots/InventoryStackSlot` into compliance with the repository `skills/test-naming` convention so method, context, parameter, and expected-result segments are clear and consistent.

### Description
- Renamed test methods in 12 files under `tests/Slots/InventoryStackSlot` to the pattern `[MethodName]_[Class_Context/State]_[ParamContext]*_[ExpectedResult]`, for example `Add_Empty_AddsToContent` → `Add_EmptySlot_AddsItem` and `Add_NullItem_ThrowsNullArgumentException` (fixed wording).
- Standardized overload distinctions and plurality (e.g. `ReplaceItem` vs `ReplaceItems`) and normalized exception/result phrasing such as `ThrowsArgumentNullException`, `ReturnsTrue`, `DoesntAddItems` and `SlotWith...` contexts.
- Renamed get/get-all/get-amount/available-amount tests to explicitly reference slot state and semantic outcomes (e.g. `GetAll_FullSlot_ReturnsAllItems`).
- Verified the changes with a repository scan to ensure no duplicate test method names were introduced.

### Testing
- Ran a duplicate-name scan (Python) which enumerated `96` test methods and reported no duplicates.
- Attempted to run `dotnet test`, but the restore failed because the NuGet service index at `https://api.nuget.org/v3/index.json` could not be loaded, so tests could not be executed end-to-end.
- Performed automated text replacements and local file checks to confirm the renames were applied consistently across the target folder.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8065a4c5888323b4789e10a8cf791a)