### PR TITLE
Rename InventorySlot tests to follow repository test-naming convention

### DIFF
--- a/tests/Slots/InventorySlot/InventorySlotTests.CanAdd.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.CanAdd.cs
@@ -30,7 +30,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void CanAdd_Empty_ReturnsTrue()
+        public void CanAdd_EmptySlot_ReturnsTrue()
         {
             var item = this.itemFactory.CreateDefault();
             var slot = this.slotFactory.Empty();
@@ -41,7 +41,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void CanAdd_Full_ReturnsFalse()
+        public void CanAdd_FullSlot_ReturnsFalse()
         {
             var item = this.itemFactory.CreateDefault();
             var slot = this.slotFactory.Full(item);

--- a/tests/Slots/InventorySlot/InventorySlotTests.CanReplace.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.CanReplace.cs
@@ -18,7 +18,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void CanReplace_DefaultValue_ReturnsTrue()
+        public void CanReplace_DefaultItem_ReturnsTrue()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -29,7 +29,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void CanReplace_Empty_ReturnsFalse()
+        public void CanReplace_EmptySlot_ReturnsFalse()
         {
             var slot = this.slotFactory.Empty();
 
@@ -40,7 +40,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void CanReplace_Full_ReturnsTrue()
+        public void CanReplace_FullSlot_ReturnsTrue()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -52,7 +52,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void CanReplace_Full_SameItem_ReturnsTrue()
+        public void CanReplace_FullSlot_SameItem_ReturnsTrue()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -63,7 +63,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void CanReplace_Full_DifferentItem_ReturnsTrue()
+        public void CanReplace_FullSlot_DifferentItem_ReturnsTrue()
         {
             var originalItem = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(originalItem);

--- a/tests/Slots/InventorySlot/InventorySlotTests.TryAdd.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.TryAdd.cs
@@ -77,7 +77,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void TryAdd_FullSlot_DoesNotAddItem()
+        public void TryAdd_FullSlot_DoesntAddItem()
         {
             var item = this.itemFactory.CreateDefault();
             var slot = this.slotFactory.Full(item);
@@ -89,7 +89,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryAdd_DefaultItem_FullSlot_DoesNotAddItem()
+        public void TryAdd_FullSlot_DefaultItem_DoesntAddItem()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -102,7 +102,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryAdd_DefaultItem_FullSlot_ReturnsFalse()
+        public void TryAdd_FullSlot_DefaultItem_ReturnsFalse()
         {
             var slot = this.slotFactory.Full(default!);
 

--- a/tests/Slots/InventorySlot/InventorySlotTests.TryReplace.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.TryReplace.cs
@@ -32,7 +32,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void TryReplace_EmptySlot_DoesNotAddsItem()
+        public void TryReplace_EmptySlot_DoesntAddItem()
         {
             var slot = this.slotFactory.Empty();
 
@@ -67,7 +67,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryReplace_EmptySlot_DefaultItem_DoesNotAddsItem()
+        public void TryReplace_EmptySlot_DefaultItem_DoesntAddItem()
         {
             var slot = this.slotFactory.Empty();
 
@@ -133,7 +133,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryReplace_DefaultItem_FullSlot_ReturnsTrue()
+        public void TryReplace_FullSlot_DefaultItem_ReturnsTrue()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -146,7 +146,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryReplace_DefaultItem_FullSlot_AddsDefault()
+        public void TryReplace_FullSlot_DefaultItem_ReplacesItemWithDefault()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -163,7 +163,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryReplace_DefaultItem_FullSlot_SetsOldItemToInitialItem()
+        public void TryReplace_FullSlot_DefaultItem_SetsOldItemToInitialItem()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -176,7 +176,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryReplace_DefaultItem_FullSlot_DefaultContent_ReturnsTrue()
+        public void TryReplace_FullSlotWithDefaultContent_ReturnsTrue()
         {
             var slot = this.slotFactory.Full(default!);
 
@@ -188,7 +188,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryReplace_DefaultItem_FullSlot_DefaultContent_AddsItem()
+        public void TryReplace_FullSlotWithDefaultContent_ReplacesDefaultWithItem()
         {
             var slot = this.slotFactory.Full(default!);
 
@@ -200,7 +200,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void TryReplace_DefaultItem_FullSlot_DefaultContent_SetsOldItemToDefault()
+        public void TryReplace_FullSlotWithDefaultContent_SetsOldItemToDefault()
         {
             var slot = this.slotFactory.Full(default!);
 

--- a/tests/Slots/InventorySlot/InventorySlotTests.add.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.add.cs
@@ -21,7 +21,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         #region State Validation
         [Test]
-        public void Add_Full_ThrowsInvalidOperationException()
+        public void Add_FullSlot_ThrowsInvalidOperationException()
         {
             var item = this.itemFactory.CreateDefault();
             var slot = this.slotFactory.Full(item);
@@ -34,7 +34,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void Add_Full_DoesNotAddItem()
+        public void Add_FullSlot_DoesntAddItem()
         {
             var item = this.itemFactory.CreateDefault();
             var slot = this.slotFactory.Full(item);
@@ -49,7 +49,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Add_Full_DefaultItem_ThrowsInvalidOperationException()
+        public void Add_FullSlot_DefaultItem_ThrowsInvalidOperationException()
         {
             var slot = this.slotFactory.Full(default!);
 
@@ -62,7 +62,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Add_Full_DefaultItem_DoesNotAddsItem()
+        public void Add_FullSlot_DefaultItem_DoesntAddItem()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -78,7 +78,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         #region Behavior
         [Test]
-        public void Add_Empty_AddsItem()
+        public void Add_EmptySlot_AddsItem()
         {
             var slot = this.slotFactory.Empty();
 
@@ -90,7 +90,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Add_Empty_DefaultItem_AddsItem()
+        public void Add_EmptySlot_DefaultItem_AddsItem()
         {
             var slot = this.slotFactory.Empty();
 

--- a/tests/Slots/InventorySlot/InventorySlotTests.get.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.get.cs
@@ -7,7 +7,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
     {
         #region Empty
         [Test]
-        public void GetOne_EmptySlot_ThrowsInvalidOperationException()
+        public void Get_EmptySlot_ThrowsInvalidOperationException()
         {
             var slot = this.slotFactory.Empty();
 
@@ -20,7 +20,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         #region Full
         [Test]
-        public void GetOne_FullSlot_ReturnsItem()
+        public void Get_FullSlot_ReturnsItem()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -32,7 +32,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void GetOne_FullSlot_RemovesItemFromSlot()
+        public void Get_FullSlot_RemovesItem()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -48,7 +48,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void GetOne_FullSlot_DefaultValue_RemovesItemFromSlot()
+        public void Get_FullSlot_DefaultItem_RemovesItem()
         {
             var item = default(T);
             var slot = this.slotFactory.Full(item!);
@@ -64,7 +64,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void GetOne_FullSlot_DefaultValue_ReturnsItem()
+        public void Get_FullSlot_DefaultItem_ReturnsItem()
         {
             var item = default(T);
             var slot = this.slotFactory.Full(item!);

--- a/tests/Slots/InventorySlot/InventorySlotTests.replace.cs
+++ b/tests/Slots/InventorySlot/InventorySlotTests.replace.cs
@@ -18,7 +18,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void Replace_Empty_ThrowsInvalidOperationException()
+        public void Replace_EmptySlot_ThrowsInvalidOperationException()
         {
             var slot = this.slotFactory.Empty();
 
@@ -30,7 +30,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void Replace_Empty_DoesNotReplacesItem()
+        public void Replace_EmptySlot_DoesntReplaceItem()
         {
             var slot = this.slotFactory.Empty();
 
@@ -43,7 +43,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void Replace_Full_ReturnsOldItem()
+        public void Replace_FullSlot_ReturnsOldItem()
         {
             var initialItem = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(initialItem);
@@ -55,7 +55,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
         }
 
         [Test]
-        public void Replace_Full_AddsNewItem()
+        public void Replace_FullSlot_ReplacesItem()
         {
             var initialItem = this.itemFactory.CreateDefault();
             var slot = this.slotFactory.Full(initialItem);
@@ -68,7 +68,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Replace_DefaultValue_Full_ReturnsItem()
+        public void Replace_FullSlot_DefaultItem_ReturnsOldItem()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -81,7 +81,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Replace_DefaultValue_Full_AddsDefault()
+        public void Replace_FullSlot_DefaultItem_ReplacesItemWithDefault()
         {
             var item = this.itemFactory.CreateRandom();
             var slot = this.slotFactory.Full(item);
@@ -98,7 +98,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Replace_FullWithDefaultContent_ReturnsDefault()
+        public void Replace_FullSlotWithDefaultContent_ReturnsDefault()
         {
             var slot = this.slotFactory.Full(default!);
 
@@ -110,7 +110,7 @@ namespace TheChest.Inventories.Tests.Slots.InventorySlot
 
         [Test]
         [IgnoreIfReferenceType]
-        public void Replace_FullWithDefaultContent_AddsItem()
+        public void Replace_FullSlotWithDefaultContent_ReplacesDefaultWithItem()
         {
             var slot = this.slotFactory.Full(default!);
 


### PR DESCRIPTION
### Motivation
- Align test method names under `tests/Slots/InventorySlot` with the repository's test naming convention so names convey method, class state, parameter context, and expected result.
- Prefer consistent state/context segments (`EmptySlot`, `FullSlot`, `DefaultItem`) and behavior-oriented expected results across these tests.

### Description
- Renamed test methods in the InventorySlot test partials to match the `MethodName_[Class_Context/State]_[ParamContext]*_[ExpectedResult]` pattern across seven files: `InventorySlotTests.CanAdd.cs`, `InventorySlotTests.CanReplace.cs`, `InventorySlotTests.TryAdd.cs`, `InventorySlotTests.TryReplace.cs`, `InventorySlotTests.add.cs`, `InventorySlotTests.get.cs`, and `InventorySlotTests.replace.cs`.
- Standardized context segments from `Empty`/`Full`/`DefaultValue`/`GetOne` to `EmptySlot`/`FullSlot`/`DefaultItem`/`Get` and normalized negative-result wording (e.g. `DoesntAddItem`, `DoesntReplaceItem`) and replacement/result phrasing (e.g. `ReplacesItemWithDefault`, `ReplacesDefaultWithItem`).
- Updated names preserve original test intent and assertions without other behavioral changes.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff issues and it completed successfully.
- Attempted `dotnet test TheChest.Inventories.sln` but the run failed during package restore with NuGet error `NU1301` due to inability to reach `https://api.nuget.org/v3/index.json` in the environment, so unit tests could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8065d95c108323aadb9221ecfe769d)