### PR TITLE
Move test-naming examples to references and convert to tables

### DIFF
--- a/skills/test-naming/SKILL.md
+++ b/skills/test-naming/SKILL.md
@@ -7,6 +7,8 @@ description: Repository-specific naming conventions for unit tests, including me
 
 Use this skill whenever creating or updating unit test names in this repository.
 
+For examples, see `references/examples.md`.
+
 ## Naming Convention
 
 Tests must follow this naming pattern:
@@ -31,24 +33,6 @@ The naming convention is composed of four parts:
 * When the method has overloads, include the relevant parameter distinction in the test method name.
 * The overload distinction should describe the parameter type or semantic role, not the exact C# type syntax.
 
-#### Examples
-
-* `Add(T item)`
-	* No overloads -> `Add_`
-	* Has overload -> `AddItem_`
-* `Add(int index)`
-	* No overloads -> `Add_`
-	* Has overload -> `AddAtIndex_`
-* `Get(int index)`
-	* No overloads -> `Get_`
-	* Has overload -> `GetByIndex_`
-* `Get(T item)`
-	* No overloads -> `Get_`
-	* Has overload -> `GetItem_`
-* `Move(int origin, int target)`
-	* No overloads -> `Move_`
-	* Has overload -> `MoveByIndex_`
-
 ---
 ### Class Context/State
 
@@ -57,17 +41,6 @@ The naming convention is composed of four parts:
 * Use this when the test's behavior is primarily determined by the current state of the class.
 * Prefer concise descriptions that identify the meaningful state rather than implementation details.
 
-#### Examples
-
-* `Add_EmptySlot_AddsItem`
-  * Class Context: `EmptySlot` _(The slot has no items)_
-* `Add_FullSlot_ThrowsInvalidOperationException`
-  * Class Context: `FullSlot` _(The slot has reached its maximum capacity)_
-* `Get_EmptyContainer_ReturnsEmptyArray`
-  * Class Context: `EmptyContainer` _(The container has no items to get)_
-* `Move_FullContainer_SwapsItemsFromSlots`
-  * Class Context: `FullContainer` _(The container is fully occupied and all slots contains items)_
-  
 ---
 ### ParamContext
 
@@ -76,21 +49,6 @@ The naming convention is composed of four parts:
 * Use this when the parameter values or conditions are what distinguish the test case.
 * Describe the meaning of the parameter value rather than necessarily reproducing the literal value.
 
-#### Examples
-
-* `Add_NullItem_ThrowsArgumentNullException`
-    Param Context: `NullItem` (The item parameter is null, representing missing input)
-* `Add_DefaultValueParam_AddsToContent`
-    Param Context: `DefaultValueParam` (The parameter uses a default or uninitialized value)
-* `Move_NegativeOrigin_ThrowsArgumentOutOfRangeException`
-    Param Context: `NegativeOrigin` (The origin index is below zero, which is invalid)
-* `Move_InvalidTarget_ThrowsArgumentOutOfRangeException`
-    Param Context: `InvalidTarget` (The target index is outside the valid range)
-* `Get_ExistingItem_ReturnsItem`
-    Param Context: `ExistingItem` (The requested item exists in the collection)
-* `Get_NotFoundItem_ReturnsDefault`
-    Param Context: `NotFoundItem` (The requested item does not exist in the collection)
-    
 ---
 ### ExpectedResult
 
@@ -108,80 +66,27 @@ The naming convention is composed of four parts:
 Use `Throws[ExceptionType]` when the primary expected outcome is an exception.
 Do not use generic results such as `Fails`, `ThrowsException`, or `ThrowsError` when the specific exception type is part of the contract.
 
-##### Examples
-
-* `Add_NullItem_ThrowsArgumentNullException`
-    * Expected Result: `ThrowsArgumentNullException`
-* `Get_InvalidIndex_ThrowsArgumentOutOfRangeException`
-    * Expected Result: `ThrowsArgumentOutOfRangeException`
-* `Replace_EmptySlot_ThrowsInvalidOperationException`
-    * Expected Result: `ThrowsInvalidOperationException`
-* `Move_SameOriginAndTarget_ThrowsArgumentException`
-    * Expected Result: `ThrowsArgumentException` 
-
 #### State Change Results
 
 Describe the resulting state or behavior when the method changes the state of the object.
 Prefer the resulting behavior over implementation details.
 
-##### Examples
-
-* `Get_ExistingItem_RemovesItem`
-    * Expected Result: `RemovesItem`
-    * Preferred over `RemovesFromContentField`
-* `Clear_FullContainer_ClearsAllSlots`
-    * Expected Result: `ClearsAllSlots` 
-    * Preferred over `ClearsContentField`
-* `Add_EmptySlot_AddsItem`
-    * Expected Result: `AddsItem`
-    * Preferred over `SetsContentField`
-* `Move_ValidOriginAndTarget_SwapsItemsFromSlots`
-    * Expected Result: `SwapsItemsFromSlots`
-    * Preferred over `SwapsContentFields`
-* `Add_EmptySlot_IncreasesSize`
-    * Expected Result: `IncreasesSize`
-    * Preferred over `IncrementsSizeField`
-* `Remove_ExistingItem_DecreasesSize`
-    * Expected Result: `DecreasesSize`
-    * Preferred over `DecrementsSizeField`
-
 #### Return Value Results
 
 Describe the semantic meaning of the returned value.
 
-Use a descriptive result such as `ReturnsItem` or `ReturnsDefault` when the actual value has meaningful semantics. 
+Use a descriptive result such as `ReturnsItem` or `ReturnsDefault` when the actual value has meaningful semantics.
 Use `ReturnsTrue` or `ReturnsFalse` when the boolean result itself is the relevant outcome.
-
-##### Examples
-
-* `Contains_ExistingItem_ReturnsTrue`
-* `Contains_NotFoundItem_ReturnsFalse`
-* `CanAdd_FullSlot_ReturnsFalse`
-* `CanMove_EmptyTarget_ReturnsTrue`
 
 #### Event and Callback Results
 
 Describe whether the expected event or callback was invoked.
 Use `Calls[EventOrCallback]` and `DoesntCall[EventOrCallback]` consistently.
 
-##### Examples
-
-* `Add_EmptySlot_CallsOnAddEvent`
-* `Add_FullSlot_CallsOnAdd`
-* `Get_FoundItem_CallsOnGetEvent`
-* `Move_ValidOriginAndTarget_CallsOnMoveEvent`
-
 #### Negative Results
 
 When the important outcome is that something does **not** happen, use `Doesnt[Behavior]`.
 The negative result should identify the behavior that is expected not to occur. Avoid vague names such as `DoesntFail` or `NoChange` unless the absence of any state change is itself the specific contract being tested.
-
-##### Examples
-
-* `Add_SlotCannotAdd_DoesntAddToSlot`
-* `Add_SlotCannotAdd_DoesntCallOnAdd`
-* `Get_FoundItem_DoesntCallOnGetEvent`
-* `Move_InvalidOrigin_DoesntChangeSlots`
 
 ---
 ## Combining Context and State
@@ -194,26 +99,8 @@ When both contexts are relevant, `Class_Context/State` comes before `ParamContex
 
 ### Valid forms
 
-* `[MethodName]_[Class_Context/State]_[ExpectedResult]` 
+* `[MethodName]_[Class_Context/State]_[ExpectedResult]`
 * `[MethodName]_[ParamContext]_[ExpectedResult]`
 * `[MethodName]_[Class_Context/State]_[ParamContext]_[ExpectedResult]`
-
-### Examples
-
-* `Add_EmptySlot_DefaultValueParam_AddsToContent`
-    * Class Context: `EmptySlot` (The slot is empty and ready to receive new data)
-    * Param Context: `DefaultValueParam` (The input value is a default or uninitialized value)
-* `Add_SlotWithSameItem_ExistingItemParam_StacksItem`
-    * Class Context: `SlotWithSameItem` (The slot already contains the same item type)
-    * Param Context: `ExistingItemParam` (The provided item matches the existing item type)
-* `Add_SlotWithNotEnoughSpace_LargeAmount_ThrowsInvalidOperationException`
-    * Class Context: `SlotWithNotEnoughSpace` (The slot has limited remaining capacity)
-    * Param Context: `LargeAmount` (The requested amount exceeds available space)
-* `Move_SlotWithItems_NegativeOrigin_ThrowsArgumentOutOfRangeException`
-    * Class Context: `SlotWithItems` (The slot contains movable items)
-    * Param Context: `NegativeOrigin` (The origin index is invalid because it is negative)
-* `Get_FullContainer_ExistingItem_ReturnsItem`
-    * Class Context: `FullContainer` (The container is fully populated with items)
-    * Param Context: `ExistingItem` (The item being removed is present in the container)
 
 Do not add context segments merely to make the test name longer. Each segment should communicate information necessary to distinguish or understand the test case.

--- a/skills/test-naming/references/examples.md
+++ b/skills/test-naming/references/examples.md
@@ -1,0 +1,90 @@
+# Test Naming Examples
+
+Use these examples together with the naming convention in `../SKILL.md`.
+
+## MethodName
+
+| Method signature | No overloads | Has overload |
+| --- | --- | --- |
+| `Add(T item)` | `Add_` | `AddItem_` |
+| `Add(int index)` | `Add_` | `AddAtIndex_` |
+| `Get(int index)` | `Get_` | `GetByIndex_` |
+| `Get(T item)` | `Get_` | `GetItem_` |
+| `Move(int origin, int target)` | `Move_` | `MoveByIndex_` |
+
+## Class Context/State
+
+| Test name | Class context | Meaning |
+| --- | --- | --- |
+| `Add_EmptySlot_AddsItem` | `EmptySlot` | The slot has no items. |
+| `Add_FullSlot_ThrowsInvalidOperationException` | `FullSlot` | The slot has reached its maximum capacity. |
+| `Get_EmptyContainer_ReturnsEmptyArray` | `EmptyContainer` | The container has no items to get. |
+| `Move_FullContainer_SwapsItemsFromSlots` | `FullContainer` | The container is fully occupied and all slots contain items. |
+
+## ParamContext
+
+| Test name | Param context | Meaning |
+| --- | --- | --- |
+| `Add_NullItem_ThrowsArgumentNullException` | `NullItem` | The item parameter is null, representing missing input. |
+| `Add_DefaultValueParam_AddsToContent` | `DefaultValueParam` | The parameter uses a default or uninitialized value. |
+| `Move_NegativeOrigin_ThrowsArgumentOutOfRangeException` | `NegativeOrigin` | The origin index is below zero, which is invalid. |
+| `Move_InvalidTarget_ThrowsArgumentOutOfRangeException` | `InvalidTarget` | The target index is outside the valid range. |
+| `Get_ExistingItem_ReturnsItem` | `ExistingItem` | The requested item exists in the collection. |
+| `Get_NotFoundItem_ReturnsDefault` | `NotFoundItem` | The requested item does not exist in the collection. |
+
+## Exception Results
+
+| Test name | Expected result |
+| --- | --- |
+| `Add_NullItem_ThrowsArgumentNullException` | `ThrowsArgumentNullException` |
+| `Get_InvalidIndex_ThrowsArgumentOutOfRangeException` | `ThrowsArgumentOutOfRangeException` |
+| `Replace_EmptySlot_ThrowsInvalidOperationException` | `ThrowsInvalidOperationException` |
+| `Move_SameOriginAndTarget_ThrowsArgumentException` | `ThrowsArgumentException` |
+
+## State Change Results
+
+| Test name | Expected result | Preferred over |
+| --- | --- | --- |
+| `Get_ExistingItem_RemovesItem` | `RemovesItem` | `RemovesFromContentField` |
+| `Clear_FullContainer_ClearsAllSlots` | `ClearsAllSlots` | `ClearsContentField` |
+| `Add_EmptySlot_AddsItem` | `AddsItem` | `SetsContentField` |
+| `Move_ValidOriginAndTarget_SwapsItemsFromSlots` | `SwapsItemsFromSlots` | `SwapsContentFields` |
+| `Add_EmptySlot_IncreasesSize` | `IncreasesSize` | `IncrementsSizeField` |
+| `Remove_ExistingItem_DecreasesSize` | `DecreasesSize` | `DecrementsSizeField` |
+
+## Return Value Results
+
+| Test name | Expected result |
+| --- | --- |
+| `Contains_ExistingItem_ReturnsTrue` | `ReturnsTrue` |
+| `Contains_NotFoundItem_ReturnsFalse` | `ReturnsFalse` |
+| `CanAdd_FullSlot_ReturnsFalse` | `ReturnsFalse` |
+| `CanMove_EmptyTarget_ReturnsTrue` | `ReturnsTrue` |
+
+## Event and Callback Results
+
+| Test name | Expected result |
+| --- | --- |
+| `Add_EmptySlot_CallsOnAddEvent` | `CallsOnAddEvent` |
+| `Add_FullSlot_CallsOnAdd` | `CallsOnAdd` |
+| `Get_FoundItem_CallsOnGetEvent` | `CallsOnGetEvent` |
+| `Move_ValidOriginAndTarget_CallsOnMoveEvent` | `CallsOnMoveEvent` |
+
+## Negative Results
+
+| Test name | Expected result |
+| --- | --- |
+| `Add_SlotCannotAdd_DoesntAddToSlot` | `DoesntAddToSlot` |
+| `Add_SlotCannotAdd_DoesntCallOnAdd` | `DoesntCallOnAdd` |
+| `Get_FoundItem_DoesntCallOnGetEvent` | `DoesntCallOnGetEvent` |
+| `Move_InvalidOrigin_DoesntChangeSlots` | `DoesntChangeSlots` |
+
+## Combining Context and State
+
+| Test name | Class context | Param context |
+| --- | --- | --- |
+| `Add_EmptySlot_DefaultValueParam_AddsToContent` | `EmptySlot` (The slot is empty and ready to receive new data) | `DefaultValueParam` (The input value is a default or uninitialized value) |
+| `Add_SlotWithSameItem_ExistingItemParam_StacksItem` | `SlotWithSameItem` (The slot already contains the same item type) | `ExistingItemParam` (The provided item matches the existing item type) |
+| `Add_SlotWithNotEnoughSpace_LargeAmount_ThrowsInvalidOperationException` | `SlotWithNotEnoughSpace` (The slot has limited remaining capacity) | `LargeAmount` (The requested amount exceeds available space) |
+| `Move_SlotWithItems_NegativeOrigin_ThrowsArgumentOutOfRangeException` | `SlotWithItems` (The slot contains movable items) | `NegativeOrigin` (The origin index is invalid because it is negative) |
+| `Get_FullContainer_ExistingItem_ReturnsItem` | `FullContainer` (The container is fully populated with items) | `ExistingItem` (The item being removed is present in the container) |


### PR DESCRIPTION
### Motivation

- Improve readability and discoverability by moving lengthy example lists out of the main skill file and presenting them as structured tables in a dedicated references document.

### Description

- Remove inline bullet-list examples from `skills/test-naming/SKILL.md` and add a link pointing to `references/examples.md` for examples.
- Add `skills/test-naming/references/examples.md` containing the original examples converted into Markdown tables and organized by section (MethodName, Class Context/State, ParamContext, Exception/Return/Event/Negative/Combining examples).
- Perform small formatting cleanups in `SKILL.md` to keep the naming rules concise and focused while delegating concrete examples to the references file.

### Testing

- Ran `git diff --check` to validate whitespace and formatting and it completed with no reported issues.
- Inspected repository changes with `git status` and reviewed `skills/test-naming/SKILL.md` and `skills/test-naming/references/examples.md` to confirm the examples were moved and converted to tables.
- Attempted `gh pr create` to open a pull request but it failed due to missing GitHub CLI authentication in this environment, so no remote PR was created from here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8084ef40688323b73be264add107ae)